### PR TITLE
Ignore local clone of claude-methodology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 build/
 dist/
 *.spec
+
+# Local copy of the working methodology — see https://github.com/aveloz89/claude-methodology
+claude-methodology/


### PR DESCRIPTION
## Summary
- Cada repo donde se use la metodologia obtiene su propia copia local via `git clone https://github.com/aveloz89/claude-methodology.git`
- El repo padre no necesita trackearla — se gitignorea

## Test plan
- [x] `git status` no muestra `claude-methodology/` como untracked tras clonarlo
- [x] El `.gitignore` deja claro que es una copia local de la metodologia