### PR TITLE
feat: add /coach view for improvement-focused stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import sys
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
@@ -92,13 +93,15 @@ class Hub:
 # so a malicious page in the user's browser can't open a WS to read PII.
 # We accept any port — the user controls --port via CLI, and same-machine origin
 # is the threat model we care about, not a specific port.
-LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+# Note: "null" Origin is intentionally rejected. It's set by sandboxed iframes
+# (`<iframe sandbox>` without `allow-same-origin`) and `data:`/`blob:` contexts —
+# any external site can mint such an iframe and would otherwise reach this WS.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
 
 def _origin_allowed(origin: str | None) -> bool:
-    if origin is None or origin == "null":
+    if origin is None:  # OBS Browser Source omits the header
         return True
-    from urllib.parse import urlparse
     try:
         parsed = urlparse(origin)
     except ValueError:

--- a/app.py
+++ b/app.py
@@ -90,17 +90,22 @@ class Hub:
 
 # OBS Browser Source omits Origin; browsers always set it. Restrict to loopback
 # so a malicious page in the user's browser can't open a WS to read PII.
-WS_ALLOWED_ORIGINS = {
-    "http://127.0.0.1:8080",
-    "http://localhost:8080",
-    "null",
-}
+# We accept any port — the user controls --port via CLI, and same-machine origin
+# is the threat model we care about, not a specific port.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
 
 
 def _origin_allowed(origin: str | None) -> bool:
-    if origin is None:
+    if origin is None or origin == "null":
         return True
-    return origin in WS_ALLOWED_ORIGINS
+    from urllib.parse import urlparse
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in ("http", "https", "ws", "wss"):
+        return False
+    return (parsed.hostname or "") in LOOPBACK_HOSTS
 
 
 hub = Hub()

--- a/app.py
+++ b/app.py
@@ -14,7 +14,14 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from state import MatchAggregator
-from storage import load_config, open_db, save_config, save_match, today_stats
+from storage import (
+    coach_stats,
+    load_config,
+    open_db,
+    save_config,
+    save_match,
+    today_stats,
+)
 from tcp_client import stream_events
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -44,6 +51,8 @@ class Hub:
     old live match snapshot.
     """
 
+    CACHED_TYPES = ("today", "coach", "match")
+
     def __init__(self) -> None:
         self._clients: set[asyncio.Queue[str]] = set()
         self._latest: dict[str, str] = {}
@@ -51,7 +60,7 @@ class Hub:
     def subscribe(self) -> asyncio.Queue[str]:
         q: asyncio.Queue[str] = asyncio.Queue(maxsize=64)
         self._clients.add(q)
-        for key in ("today", "match"):
+        for key in self.CACHED_TYPES:
             cached = self._latest.get(key)
             if cached is not None:
                 try:
@@ -66,7 +75,7 @@ class Hub:
     def publish(self, payload: dict) -> None:
         msg_type = payload.get("type")
         body = json.dumps(payload)
-        if msg_type in ("match", "today"):
+        if msg_type in self.CACHED_TYPES:
             self._latest[msg_type] = body
         for q in list(self._clients):
             try:
@@ -121,6 +130,14 @@ EMPTY_TODAY = {
     "total_ball_hits": 0, "best_hit": 0, "win_streak": 0,
 }
 
+EMPTY_COACH = {
+    "last_match": None,
+    "rolling_avg": {"count": 0},
+    "trend": [],
+    "insights": [],
+    "today": dict(EMPTY_TODAY),
+}
+
 
 def _broadcast_match() -> None:
     snap = agg.to_overlay_dict()
@@ -132,6 +149,13 @@ def _broadcast_today() -> None:
         hub.publish({"type": "today", "data": dict(EMPTY_TODAY)})
         return
     hub.publish({"type": "today", "data": today_stats(db, agg.me_id)})
+
+
+def _broadcast_coach() -> None:
+    if not agg.me_id or db is None:
+        hub.publish({"type": "coach", "data": dict(EMPTY_COACH)})
+        return
+    hub.publish({"type": "coach", "data": coach_stats(db, agg.me_id)})
 
 
 def _persist_current_match() -> bool:
@@ -164,6 +188,7 @@ def handle_event(event: dict) -> None:
         if agg.is_match_guid_change(data):
             _persist_current_match()
             _broadcast_today()
+            _broadcast_coach()
         detected = agg.on_update_state(data)
         if detected:
             log.info("identity detected: %s (%s)", detected["name"], detected["id"])
@@ -179,6 +204,7 @@ def handle_event(event: dict) -> None:
     if name in MATCH_END_EVENTS:
         _persist_current_match()
         _broadcast_today()
+        _broadcast_coach()
         return
 
 
@@ -204,18 +230,22 @@ async def _demo_match() -> None:  # pragma: no cover — preview-only synthetic 
     teammate = {"Name": "kuxir", "PrimaryId": "Steam|2|0", "TeamNum": 0, "Shortcut": 2}
     opp = {"Name": "jstn", "PrimaryId": "Epic|3|0", "TeamNum": 1, "Shortcut": 3}
 
-    me_state = {
-        "Name": me_name, "PrimaryId": me_id, "TeamNum": 0, "Shortcut": 1,
-        "Score": 0, "Goals": 0, "Shots": 0, "Saves": 0, "Assists": 0,
-        "Demos": 0, "Touches": 0, "CarTouches": 0,
-        "bOnGround": True, "bHasCar": True, "Speed": 0.0, "Boost": 50,
-    }
-    teammate_state = {**teammate, "Score": 0, "Goals": 0, "Shots": 0, "Saves": 0,
-                      "Assists": 0, "Demos": 0, "Touches": 0, "CarTouches": 0,
-                      "bOnGround": True, "bHasCar": True, "Speed": 0.0, "Boost": 50}
-    opp_state = {**opp, "Score": 0, "Goals": 0, "Shots": 0, "Saves": 0,
-                 "Assists": 0, "Demos": 0, "Touches": 0, "CarTouches": 0,
-                 "bOnGround": True, "bHasCar": True, "Speed": 0.0, "Boost": 50}
+    def _player_state(base: dict, **extra) -> dict:
+        return {
+            **base,
+            "Score": 0, "Goals": 0, "Shots": 0, "Saves": 0, "Assists": 0,
+            "Demos": 0, "Touches": 0, "CarTouches": 0,
+            "bOnGround": True, "bHasCar": True, "Speed": 0.0, "Boost": 50,
+            "Location": {"X": 0.0, "Y": -2000.0, "Z": 17.0},
+            **extra,
+        }
+
+    me_state = _player_state(
+        {"Name": me_name, "PrimaryId": me_id, "TeamNum": 0, "Shortcut": 1}
+    )
+    teammate_state = _player_state(teammate, Location={"X": 1500.0, "Y": -1500.0, "Z": 17.0})
+    opp_state = _player_state(opp, Location={"X": 0.0, "Y": 2000.0, "Z": 17.0})
+    ball_loc = {"X": 0.0, "Y": 0.0, "Z": 90.0}
 
     handle_event({"Event": "Initialized", "Data": {"MatchGuid": f"DEMO-{int(time.time())}"}})
 
@@ -226,12 +256,26 @@ async def _demo_match() -> None:  # pragma: no cover — preview-only synthetic 
 
     # Short demo match (real time ~20s) so the today panel populates quickly
     while elapsed < 20:
-        # Live tick: fluctuate boost, speed, ground state
+        # Live tick: fluctuate boost, speed, ground state and positioning
         for s in (me_state, teammate_state, opp_state):
-            s["Boost"] = max(0, min(100, s["Boost"] + random.randint(-7, 7)))
+            # Occasional pad pickup so big/small/stolen counters move
+            if random.random() < 0.04 and s["Boost"] <= 12:
+                s["Boost"] = 100
+            elif random.random() < 0.08:
+                s["Boost"] = min(100, s["Boost"] + 12)
+            else:
+                s["Boost"] = max(0, min(100, s["Boost"] + random.randint(-7, 4)))
             # Speed mostly below supersonic (22) so % supersonic looks realistic
             s["Speed"] = max(0.0, min(35.0, s["Speed"] * 0.6 + random.uniform(0, 20)))
             s["bOnGround"] = random.random() > 0.25
+            loc = s["Location"]
+            loc["X"] = max(-3500.0, min(3500.0, loc["X"] + random.uniform(-200, 200)))
+            loc["Y"] = max(-4500.0, min(4500.0, loc["Y"] + random.uniform(-300, 300)))
+            loc["Z"] = 17.0 if s["bOnGround"] else random.uniform(150.0, 1200.0)
+
+        ball_loc["X"] = max(-3500.0, min(3500.0, ball_loc["X"] + random.uniform(-300, 300)))
+        ball_loc["Y"] = max(-4500.0, min(4500.0, ball_loc["Y"] + random.uniform(-400, 400)))
+        ball_loc["Z"] = max(90.0, min(1500.0, ball_loc["Z"] + random.uniform(-100, 200)))
 
         update = {
             "Event": "UpdateState",
@@ -247,7 +291,11 @@ async def _demo_match() -> None:  # pragma: no cover — preview-only synthetic 
                     ],
                     "TimeSeconds": max(0, 300 - int(elapsed)),
                     "bOvertime": False,
-                    "Ball": {"Speed": random.uniform(20, 90), "TeamNum": 1},
+                    "Ball": {
+                        "Speed": random.uniform(20, 90),
+                        "TeamNum": 1,
+                        "Location": dict(ball_loc),
+                    },
                     "bReplay": False,
                     "bHasWinner": False,
                     "Winner": "",
@@ -274,7 +322,7 @@ async def _demo_match() -> None:  # pragma: no cover — preview-only synthetic 
                         "Ball": {
                             "PreHitSpeed": random.uniform(20, 60),
                             "PostHitSpeed": random.uniform(60, 110),
-                            "Location": {"X": 0, "Y": 0, "Z": 100},
+                            "Location": dict(ball_loc),
                         },
                     },
                 })
@@ -369,12 +417,24 @@ async def index() -> FileResponse:
     return FileResponse(STATIC_DIR / "index.html")
 
 
+@app.get("/coach")
+async def coach() -> FileResponse:
+    return FileResponse(STATIC_DIR / "coach.html")
+
+
 @app.get("/api/today")
 async def api_today() -> dict:
     if not agg.me_id or db is None:
         return dict(EMPTY_TODAY)
     # Run SQLite I/O in a thread so a slow disk doesn't block the event loop.
     return await asyncio.to_thread(today_stats, db, agg.me_id)
+
+
+@app.get("/api/coach")
+async def api_coach() -> dict:
+    if not agg.me_id or db is None:
+        return dict(EMPTY_COACH)
+    return await asyncio.to_thread(coach_stats, db, agg.me_id)
 
 
 @app.websocket("/ws")

--- a/state.py
+++ b/state.py
@@ -1,4 +1,5 @@
-"""Per-match aggregator: tracks the 15 personal stats + identity detection."""
+"""Per-match aggregator: tracks personal stats, positioning, boost pickups,
+aerials and identity detection from the RL Stats API event stream."""
 
 from __future__ import annotations
 
@@ -9,10 +10,35 @@ from datetime import datetime, timezone
 # RL "Speed" in the stats API is uu/s / 100. Supersonic in-game = 2200 uu/s.
 SUPERSONIC_THRESHOLD = 22.0
 
+# Positioning thresholds (uu, after team normalization). Field is ~10240 long on Y.
+DEFENSIVE_Y = -2000.0
+OFFENSIVE_Y = 2000.0
+
+# Boost pickup heuristics — derived from frame-to-frame delta of Player.Boost.
+# Big pads grant 100 (full); small pads grant 12. Detection windows are loose
+# because we sample at 15Hz and pads can chain.
+BIG_PAD_DELTA = 90
+BIG_PAD_PREV_MAX = 12
+SMALL_PAD_MIN_DELTA = 5
+
+# Fast-aerial detection: a takeoff with boost ≥30 that reaches Z > 600 within
+# 1.5 real seconds. Z=600 is roughly above the second crossbar height.
+FAST_AERIAL_BOOST_MIN = 30
+FAST_AERIAL_Z_TARGET = 600.0
+FAST_AERIAL_WINDOW_S = 1.5
+
 LAST_TOUCH_NONE = "none"
 LAST_TOUCH_SELF = "self"
 LAST_TOUCH_TEAM = "team"
 LAST_TOUCH_OPPONENT = "opp"
+
+
+def _norm_y(y: float, team: int) -> float:
+    """Normalize Y so that <0 is always the player's defensive half.
+
+    Blue (team=0) defends the -Y side, Orange (team=1) defends the +Y side.
+    """
+    return float(y) if team == 0 else -float(y)
 
 
 @dataclass
@@ -51,6 +77,29 @@ class MatchAggregator:
 
     # Possession: total ball-hit events per team
     team_hits: dict[int, int] = field(default_factory=lambda: {0: 0, 1: 0})
+
+    # Positioning (sampled when both player and ball expose Location).
+    # frames_pos may be < frames if the build doesn't broadcast Location.
+    frames_pos: int = 0
+    frames_def_third: int = 0
+    frames_off_third: int = 0
+    frames_behind_ball: int = 0
+    frames_last_back: int = 0
+    dist_to_ball_sum: float = 0.0
+
+    # Boost pickup detection
+    big_pads: int = 0
+    small_pads: int = 0
+    boost_stolen: int = 0
+    _prev_boost: int | None = field(default=None, repr=False)
+
+    # Aerial mechanics
+    aerial_touches: int = 0
+    fast_aerials: int = 0
+    _last_on_ground: bool = field(default=True, repr=False)
+    _takeoff_at: float | None = field(default=None, repr=False)
+    _takeoff_boost: int = field(default=0, repr=False)
+    _fast_aerial_counted: bool = field(default=False, repr=False)
 
     # Match context
     blue_score: int = 0
@@ -129,6 +178,10 @@ class MatchAggregator:
         self.boost = me.get("Boost", self.boost)
         self.speed = float(me.get("Speed", self.speed))
 
+        on_ground = me.get("bOnGround")
+        if isinstance(on_ground, bool):
+            self._last_on_ground = on_ground
+
         # Derived — only count "live" frames (not replays, has car spawned at least once)
         if not self.in_replay:
             self.frames += 1
@@ -142,13 +195,17 @@ class MatchAggregator:
             if self.speed >= SUPERSONIC_THRESHOLD:
                 self.frames_supersonic += 1
 
-            if me.get("bOnGround") is False:
+            if on_ground is False:
                 self.frames_airborne += 1
 
             has_car = bool(me.get("bHasCar", True))
             if self.prev_has_car and not has_car:
                 self.demos_taken += 1
             self.prev_has_car = has_car
+
+            self._track_boost_pickup(me, boost_now)
+            self._track_position(me, game, players)
+            self._track_aerial(me, on_ground)
 
         return detected
 
@@ -175,6 +232,9 @@ class MatchAggregator:
             self.last_touch_name = self.me_name
             if post > self.hardest_hit:
                 self.hardest_hit = post
+            # Aerial touch: I last left the ground in the most recent UpdateState
+            if self._last_on_ground is False:
+                self.aerial_touches += 1
         else:
             hitter_name = names[0] if names else ""
             hitter_team = teams.get(hitter_name)
@@ -185,6 +245,103 @@ class MatchAggregator:
             else:
                 self.last_touch_kind = LAST_TOUCH_OPPONENT
             self.last_touch_name = hitter_name
+
+    def _track_boost_pickup(self, me: dict, boost_now: int) -> None:
+        prev = self._prev_boost
+        self._prev_boost = boost_now
+        if prev is None:
+            return
+        delta = boost_now - prev
+        if delta >= BIG_PAD_DELTA and prev <= BIG_PAD_PREV_MAX:
+            self.big_pads += 1
+            if self._is_in_opponent_half(me):
+                self.boost_stolen += 1
+        elif SMALL_PAD_MIN_DELTA <= delta < BIG_PAD_DELTA:
+            self.small_pads += 1
+            if self._is_in_opponent_half(me):
+                self.boost_stolen += 1
+
+    def _is_in_opponent_half(self, me: dict) -> bool:
+        loc = me.get("Location")
+        if not isinstance(loc, dict) or self.me_team < 0:
+            return False
+        y = loc.get("Y")
+        if y is None:
+            return False
+        return _norm_y(y, self.me_team) > 0
+
+    def _track_position(self, me: dict, game: dict, players: list[dict]) -> None:
+        me_loc = me.get("Location")
+        ball = game.get("Ball") or {}
+        ball_loc = ball.get("Location")
+        if (
+            not isinstance(me_loc, dict)
+            or not isinstance(ball_loc, dict)
+            or self.me_team < 0
+            or me_loc.get("Y") is None
+            or ball_loc.get("Y") is None
+        ):
+            return
+
+        my_y = _norm_y(me_loc["Y"], self.me_team)
+        ball_y = _norm_y(ball_loc["Y"], self.me_team)
+
+        self.frames_pos += 1
+        if my_y < DEFENSIVE_Y:
+            self.frames_def_third += 1
+        elif my_y > OFFENSIVE_Y:
+            self.frames_off_third += 1
+
+        if my_y < ball_y:
+            self.frames_behind_ball += 1
+
+        # 3D distance to ball
+        dx = float(me_loc.get("X", 0.0)) - float(ball_loc.get("X", 0.0))
+        dy = float(me_loc["Y"]) - float(ball_loc["Y"])
+        dz = float(me_loc.get("Z", 0.0)) - float(ball_loc.get("Z", 0.0))
+        self.dist_to_ball_sum += (dx * dx + dy * dy + dz * dz) ** 0.5
+
+        # Last back: my normalized Y is the smallest among my own team
+        teammate_ys = [
+            _norm_y(p["Location"]["Y"], self.me_team)
+            for p in players
+            if isinstance(p.get("Location"), dict)
+            and p.get("Location", {}).get("Y") is not None
+            and p.get("TeamNum") == self.me_team
+        ]
+        if teammate_ys and my_y <= min(teammate_ys):
+            self.frames_last_back += 1
+
+    def _track_aerial(self, me: dict, on_ground: bool | None) -> None:
+        if on_ground is None:
+            return
+        now = time.monotonic()
+        boost_now = int(me.get("Boost", 0))
+        loc = me.get("Location")
+        z = float(loc["Z"]) if isinstance(loc, dict) and loc.get("Z") is not None else None
+
+        # Detect takeoff
+        if self.prev_has_car and on_ground is False and self._takeoff_at is None:
+            self._takeoff_at = now
+            self._takeoff_boost = boost_now
+            self._fast_aerial_counted = False
+
+        # Reset on landing
+        if on_ground is True:
+            self._takeoff_at = None
+            self._fast_aerial_counted = False
+            return
+
+        if (
+            self._takeoff_at is not None
+            and not self._fast_aerial_counted
+            and self._takeoff_boost >= FAST_AERIAL_BOOST_MIN
+            and z is not None
+            and z > FAST_AERIAL_Z_TARGET
+            and (now - self._takeoff_at) <= FAST_AERIAL_WINDOW_S
+        ):
+            self.fast_aerials += 1
+            self._fast_aerial_counted = True
 
     def _maybe_detect(self, players: list[dict], game: dict) -> dict | None:
         if self.me_id or self._detect_window_frames <= 0:
@@ -269,6 +426,32 @@ class MatchAggregator:
         total = self.team_hits.get(0, 0) + self.team_hits.get(1, 0)
         return round(100 * my_team_hits / total) if total > 0 else 0
 
+    def time_def_third_pct(self) -> int:
+        return round(100 * self.frames_def_third / self.frames_pos) if self.frames_pos > 0 else 0
+
+    def time_off_third_pct(self) -> int:
+        return round(100 * self.frames_off_third / self.frames_pos) if self.frames_pos > 0 else 0
+
+    def time_mid_third_pct(self) -> int:
+        if self.frames_pos == 0:
+            return 0
+        return max(0, 100 - self.time_def_third_pct() - self.time_off_third_pct())
+
+    def behind_ball_pct(self) -> int:
+        return round(100 * self.frames_behind_ball / self.frames_pos) if self.frames_pos > 0 else 0
+
+    def last_back_pct(self) -> int:
+        return round(100 * self.frames_last_back / self.frames_pos) if self.frames_pos > 0 else 0
+
+    def dist_to_ball_avg(self) -> int:
+        return round(self.dist_to_ball_sum / self.frames_pos) if self.frames_pos > 0 else 0
+
+    def air_touch_pct(self) -> int:
+        return round(100 * self.aerial_touches / self.ball_hits) if self.ball_hits > 0 else 0
+
+    def has_positioning_data(self) -> bool:
+        return self.frames_pos > 0
+
     def won(self) -> bool | None:
         if self.me_team < 0:
             return None
@@ -345,4 +528,15 @@ class MatchAggregator:
             "avg_shot_power": self.avg_shot_power(),
             "boost_wasted_pct": self.boost_wasted_pct(),
             "possession_pct": self.possession_pct(),
+            "score_per_min": self.score_per_minute(),
+            "time_def_third_pct": self.time_def_third_pct() if self.has_positioning_data() else None,
+            "time_off_third_pct": self.time_off_third_pct() if self.has_positioning_data() else None,
+            "behind_ball_pct": self.behind_ball_pct() if self.has_positioning_data() else None,
+            "last_back_pct": self.last_back_pct() if self.has_positioning_data() else None,
+            "dist_to_ball_avg": self.dist_to_ball_avg() if self.has_positioning_data() else None,
+            "big_pads": self.big_pads,
+            "small_pads": self.small_pads,
+            "boost_stolen": self.boost_stolen,
+            "aerial_touches": self.aerial_touches,
+            "fast_aerials": self.fast_aerials,
         }

--- a/state.py
+++ b/state.py
@@ -198,12 +198,19 @@ class MatchAggregator:
             if on_ground is False:
                 self.frames_airborne += 1
 
+            prev_has_car = self.prev_has_car
             has_car = bool(me.get("bHasCar", True))
-            if self.prev_has_car and not has_car:
+            if prev_has_car and not has_car:
                 self.demos_taken += 1
             self.prev_has_car = has_car
 
-            self._track_boost_pickup(me, boost_now)
+            # Skip pickup detection on death/respawn frames — boost jumps from
+            # an arbitrary value to 0 (death) and from 0 to 33 (respawn);
+            # neither is a real pad pickup.
+            if has_car and prev_has_car:
+                self._track_boost_pickup(me, boost_now)
+            else:
+                self._prev_boost = boost_now
             self._track_position(me, game, players)
             self._track_aerial(me, on_ground)
 
@@ -295,9 +302,10 @@ class MatchAggregator:
         if my_y < ball_y:
             self.frames_behind_ball += 1
 
-        # 3D distance to ball
+        # 3D distance to ball — magnitude is sign-invariant, so we can reuse
+        # the already-normalized Y values without affecting the result.
         dx = float(me_loc.get("X", 0.0)) - float(ball_loc.get("X", 0.0))
-        dy = float(me_loc["Y"]) - float(ball_loc["Y"])
+        dy = my_y - ball_y
         dz = float(me_loc.get("Z", 0.0)) - float(ball_loc.get("Z", 0.0))
         self.dist_to_ball_sum += (dx * dx + dy * dy + dz * dz) ** 0.5
 

--- a/static/coach.css
+++ b/static/coach.css
@@ -1,0 +1,443 @@
+:root {
+  --blue: #1873ff;
+  --orange: #ff8a1f;
+  --bg: #0b0d14;
+  --bg-soft: #161a26;
+  --bg-soft-hover: #1d2230;
+  --fg: #f5f5f5;
+  --muted: #9ea0aa;
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #ffd23f;
+  --good: #4ade80;
+  --warn: #f59e0b;
+  --bad: #ef4444;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-8: 3rem;
+
+  --radius: 0.75rem;
+  --radius-sm: 0.5rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  min-height: 100vh;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+[hidden] { display: none !important; }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ── Header ─────────────────────────────────────────────────────────── */
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 1.125rem;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  font-weight: 800;
+  letter-spacing: 0.18em;
+}
+
+.brand {
+  color: var(--accent);
+}
+
+.player {
+  color: var(--fg);
+  letter-spacing: 0.04em;
+  font-size: 0.875rem;
+}
+
+.conn {
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.conn[data-state="connected"] {
+  color: var(--good);
+}
+
+.conn[data-state="disconnected"] {
+  color: var(--bad);
+}
+
+/* ── Layout ─────────────────────────────────────────────────────────── */
+
+.page-main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.empty {
+  text-align: center;
+  padding: var(--space-8) var(--space-4);
+  background: var(--bg-soft);
+  border-radius: var(--radius);
+}
+
+.empty .hint {
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+/* ── Hero (last match + insights) ───────────────────────────────────── */
+
+.hero {
+  background: var(--bg-soft);
+  border-radius: var(--radius);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.hero-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.hero h2 {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.hero-meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-3);
+  font-size: 1rem;
+}
+
+.hero-meta .sep {
+  color: var(--border);
+}
+
+.result {
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+}
+
+.result[data-outcome="win"] {
+  background: rgba(74, 222, 128, 0.12);
+  color: var(--good);
+}
+
+.result[data-outcome="loss"] {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--bad);
+}
+
+.result[data-outcome="draw"] {
+  background: rgba(255, 210, 63, 0.12);
+  color: var(--accent);
+}
+
+.insights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.insights li {
+  background: var(--bg);
+  border-left: 3px solid var(--warn);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3) var(--space-4);
+  font-size: 0.9375rem;
+  color: var(--fg);
+}
+
+.insights li::before {
+  content: "▸ ";
+  color: var(--warn);
+  font-weight: 800;
+  margin-right: var(--space-1);
+}
+
+.insights-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+/* ── Categories grid ────────────────────────────────────────────────── */
+
+.cats {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+}
+
+@media (min-width: 720px) {
+  .cats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.cat {
+  background: var(--bg-soft);
+  border-radius: var(--radius);
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.cat h2 {
+  margin: 0;
+  font-size: 0.6875rem;
+  letter-spacing: 0.25em;
+  color: var(--accent);
+  font-weight: 700;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-2);
+}
+
+.rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px dashed var(--border);
+  font-size: 0.9375rem;
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.row .label {
+  color: var(--muted);
+}
+
+.row .value {
+  font-weight: 800;
+  font-size: 1.0625rem;
+}
+
+.row .compare {
+  font-size: 0.75rem;
+  color: var(--muted);
+  min-width: 4rem;
+  text-align: right;
+}
+
+.row .compare[data-trend="up"] {
+  color: var(--good);
+}
+
+.row .compare[data-trend="down"] {
+  color: var(--bad);
+}
+
+.row .compare[data-trend="flat"] {
+  color: var(--muted);
+}
+
+/* ── Trend with sparklines ──────────────────────────────────────────── */
+
+.trend {
+  background: var(--bg-soft);
+  border-radius: var(--radius);
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.trend h2 {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.trend h2 .muted {
+  color: var(--border);
+  font-weight: 500;
+}
+
+.trend-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.trend-row {
+  display: grid;
+  grid-template-columns: 9rem 1fr auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: 0.875rem;
+  padding: var(--space-2) 0;
+}
+
+.trend-row .label {
+  color: var(--muted);
+}
+
+.spark {
+  width: 100%;
+  max-width: 28rem;
+  height: 1.75rem;
+  display: block;
+}
+
+.spark path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.5;
+}
+
+.spark .area {
+  fill: rgba(255, 210, 63, 0.12);
+  stroke: none;
+}
+
+.trend-row .last {
+  font-weight: 800;
+  font-size: 1rem;
+  min-width: 3rem;
+  text-align: right;
+}
+
+.trend-row .arrow {
+  font-size: 1rem;
+  min-width: 1.25rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.trend-row .arrow[data-dir="up"] {
+  color: var(--good);
+}
+
+.trend-row .arrow[data-dir="down"] {
+  color: var(--bad);
+}
+
+/* ── Today bar ──────────────────────────────────────────────────────── */
+
+.today-bar {
+  background: var(--bg-soft);
+  border-radius: var(--radius);
+  padding: var(--space-3) var(--space-5);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-5);
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.today-bar .today-label {
+  letter-spacing: 0.25em;
+  font-weight: 800;
+  color: var(--accent);
+  font-size: 0.6875rem;
+}
+
+.today-bar strong {
+  color: var(--fg);
+  font-weight: 800;
+  font-size: 1rem;
+  margin-right: var(--space-1);
+}

--- a/static/coach.html
+++ b/static/coach.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RL Coach — stats para mejorar</title>
+    <meta name="description" content="Dashboard personal de Rocket League: último partido, posicionamiento, boost y mecánicas vs tu propio promedio." />
+    <link rel="stylesheet" href="/static/coach.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>
+        <span class="brand">COACH</span>
+        <span class="player" id="player-name">—</span>
+      </h1>
+      <span class="conn" id="conn" aria-live="polite">conectando…</span>
+    </header>
+
+    <main class="page-main">
+      <section class="empty" id="empty" hidden>
+        <p>Aún no hay partidos registrados.</p>
+        <p class="hint">Inicia Rocket League y juega un partido. Vuelve a esta página al terminar.</p>
+      </section>
+
+      <section class="hero" id="hero" hidden aria-labelledby="last-heading">
+        <header class="hero-head">
+          <h2 id="last-heading">Último partido</h2>
+          <p class="hero-meta">
+            <span class="result" id="last-result">—</span>
+            <span class="sep" aria-hidden="true">·</span>
+            <span><strong id="last-score">0</strong> score</span>
+            <span class="sep" aria-hidden="true">·</span>
+            <span><strong id="last-duration">0</strong> min</span>
+          </p>
+        </header>
+        <ul class="insights" id="insights"></ul>
+        <p class="insights-empty" id="insights-empty" hidden>
+          Sigue jugando para ver patrones — necesito al menos 5 partidos previos para sugerencias.
+        </p>
+      </section>
+
+      <section class="cats" id="cats" hidden>
+        <article class="cat">
+          <h2>Posicionamiento</h2>
+          <ul class="rows" id="cat-pos"></ul>
+        </article>
+        <article class="cat">
+          <h2>Boost (avanzado)</h2>
+          <ul class="rows" id="cat-boost"></ul>
+        </article>
+        <article class="cat">
+          <h2>Mecánica</h2>
+          <ul class="rows" id="cat-mech"></ul>
+        </article>
+      </section>
+
+      <section class="trend" id="trend-section" hidden aria-labelledby="trend-heading">
+        <h2 id="trend-heading">Tendencia <span class="muted">(últimos 14 días)</span></h2>
+        <ul class="trend-rows" id="trend-rows"></ul>
+      </section>
+
+      <section class="today-bar" id="today-bar" hidden aria-labelledby="today-heading">
+        <h2 id="today-heading" class="visually-hidden">Hoy</h2>
+        <span class="today-label">HOY</span>
+        <span><strong id="today-matches">0</strong> partidos</span>
+        <span><strong id="today-record">0V 0D</strong></span>
+        <span><strong id="today-winrate">0%</strong> WR</span>
+        <span><strong id="today-streak">0</strong> racha</span>
+        <span><strong id="today-best">0</strong> best score</span>
+      </section>
+    </main>
+
+    <script src="/static/coach.js" defer></script>
+  </body>
+</html>

--- a/static/coach.js
+++ b/static/coach.js
@@ -1,0 +1,319 @@
+(() => {
+  "use strict";
+
+  const $ = (id) => document.getElementById(id);
+
+  const conn = $("conn");
+  const empty = $("empty");
+  const hero = $("hero");
+  const cats = $("cats");
+  const trendSection = $("trend-section");
+  const todayBar = $("today-bar");
+
+  const setConn = (state, label) => {
+    conn.dataset.state = state;
+    conn.textContent = label;
+  };
+
+  // Layout: [{key, label, suffix, source: "last_match" | "rolling_avg", direction}]
+  // direction: "high_good" / "low_good" / "neutral" — controls the trend arrow color.
+  const POSITIONING_ROWS = [
+    { key: "time_def_third_pct", label: "Tercio defensivo", suffix: "%", direction: "neutral" },
+    { key: "time_off_third_pct", label: "Tercio ofensivo", suffix: "%", direction: "neutral" },
+    { key: "behind_ball_pct", label: "Detrás del balón", suffix: "%", direction: "high_good" },
+    { key: "last_back_pct", label: "Último hombre", suffix: "%", direction: "neutral" },
+    { key: "dist_to_ball_avg", label: "Distancia balón", suffix: "", direction: "neutral" },
+  ];
+
+  const BOOST_ROWS = [
+    { key: "big_pads", label: "Big pads", suffix: "", direction: "high_good" },
+    { key: "small_pads", label: "Small pads", suffix: "", direction: "high_good" },
+    { key: "boost_stolen", label: "Robado en mitad rival", suffix: "", direction: "high_good" },
+    { key: "boost_avg", label: "Avg boost", suffix: "", direction: "high_good" },
+    { key: "boost_wasted_pct", label: "Wasted", suffix: "%", direction: "low_good" },
+    { key: "time_zero_boost_pct", label: "Sin boost", suffix: "%", direction: "low_good" },
+  ];
+
+  const MECH_ROWS = [
+    { key: "aerial_touches", label: "Toques aéreos", suffix: "", direction: "high_good" },
+    { key: "air_touch_pct", label: "% toques aéreos", suffix: "%", direction: "high_good" },
+    { key: "fast_aerials", label: "Fast aerials", suffix: "", direction: "high_good" },
+    { key: "time_supersonic_pct", label: "Supersónico", suffix: "%", direction: "high_good" },
+    { key: "time_airborne_pct", label: "En el aire", suffix: "%", direction: "high_good" },
+    { key: "hardest_hit", label: "Hardest hit", suffix: "", direction: "high_good" },
+  ];
+
+  const TREND_METRICS = [
+    { key: "win_rate", label: "Win rate", suffix: "%", direction: "high_good" },
+    { key: "score_per_min", label: "Score/min", suffix: "", direction: "high_good" },
+    { key: "shot_accuracy", label: "Shot accuracy", suffix: "%", direction: "high_good" },
+    { key: "behind_ball_pct", label: "Detrás del balón", suffix: "%", direction: "high_good" },
+    { key: "possession_pct", label: "Posesión", suffix: "%", direction: "high_good" },
+  ];
+
+  const fmt = (val, suffix) => {
+    if (val === null || val === undefined) return "—";
+    const n = typeof val === "number" ? val : Number(val);
+    if (Number.isNaN(n)) return "—";
+    const rounded = Math.abs(n) >= 100 ? Math.round(n) : Math.round(n * 10) / 10;
+    return `${rounded}${suffix ?? ""}`;
+  };
+
+  const buildRow = (def, last, avg) => {
+    const li = document.createElement("li");
+    li.className = "row";
+
+    const label = document.createElement("span");
+    label.className = "label";
+    label.textContent = def.label;
+
+    const value = document.createElement("span");
+    value.className = "value";
+    const v = last?.[def.key];
+    value.textContent = v === null || v === undefined ? "—" : fmt(v, def.suffix);
+
+    const compare = document.createElement("span");
+    compare.className = "compare";
+    const a = avg?.[def.key];
+    if (a === null || a === undefined || v === null || v === undefined) {
+      compare.textContent = "";
+      compare.dataset.trend = "flat";
+    } else {
+      const diff = Number(v) - Number(a);
+      compare.textContent = `avg ${fmt(a, def.suffix)}`;
+      const tolerance = def.suffix === "%" ? 3 : Math.max(1, Math.abs(Number(a)) * 0.05);
+      if (Math.abs(diff) <= tolerance || def.direction === "neutral") {
+        compare.dataset.trend = "flat";
+      } else if ((def.direction === "high_good" && diff > 0)
+                 || (def.direction === "low_good" && diff < 0)) {
+        compare.dataset.trend = "up";
+      } else {
+        compare.dataset.trend = "down";
+      }
+    }
+
+    li.append(label, value, compare);
+    return li;
+  };
+
+  const renderRows = (containerId, defs, last, avg) => {
+    const container = $(containerId);
+    container.replaceChildren();
+    for (const def of defs) {
+      container.appendChild(buildRow(def, last, avg));
+    }
+  };
+
+  const renderInsights = (insights) => {
+    const list = $("insights");
+    const emptyMsg = $("insights-empty");
+    list.replaceChildren();
+    if (!insights || insights.length === 0) {
+      emptyMsg.hidden = false;
+      list.hidden = true;
+      return;
+    }
+    emptyMsg.hidden = true;
+    list.hidden = false;
+    for (const text of insights) {
+      const li = document.createElement("li");
+      li.textContent = text;
+      list.appendChild(li);
+    }
+  };
+
+  const buildSparkline = (values) => {
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNS, "svg");
+    svg.setAttribute("class", "spark");
+    svg.setAttribute("viewBox", "0 0 100 30");
+    svg.setAttribute("preserveAspectRatio", "none");
+    svg.setAttribute("aria-hidden", "true");
+
+    if (!values || values.length === 0) return svg;
+
+    const filtered = values.filter((v) => v !== null && v !== undefined);
+    if (filtered.length === 0) return svg;
+
+    const min = Math.min(...filtered);
+    const max = Math.max(...filtered);
+    const range = max - min || 1;
+    const stepX = values.length > 1 ? 100 / (values.length - 1) : 0;
+
+    const points = values.map((v, i) => {
+      if (v === null || v === undefined) return null;
+      const x = i * stepX;
+      const y = 28 - ((v - min) / range) * 26;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    });
+
+    const linePath = points
+      .map((p, i) => (p ? `${i === 0 ? "M" : "L"}${p}` : ""))
+      .filter(Boolean)
+      .join(" ");
+
+    const firstX = (points.findIndex((p) => p !== null) * stepX).toFixed(1);
+    const lastX = ((points.length - 1) * stepX).toFixed(1);
+    const areaPath = `${linePath} L${lastX},30 L${firstX},30 Z`;
+
+    const area = document.createElementNS(svgNS, "path");
+    area.setAttribute("d", areaPath);
+    area.setAttribute("class", "area");
+
+    const line = document.createElementNS(svgNS, "path");
+    line.setAttribute("d", linePath);
+
+    svg.append(area, line);
+    return svg;
+  };
+
+  const renderTrend = (trend) => {
+    const container = $("trend-rows");
+    container.replaceChildren();
+    if (!trend || trend.length < 2) {
+      trendSection.hidden = true;
+      return;
+    }
+    trendSection.hidden = false;
+
+    for (const metric of TREND_METRICS) {
+      const series = trend.map((d) => d[metric.key]);
+      const filtered = series.filter((v) => v !== null && v !== undefined);
+      if (filtered.length < 2) continue;
+
+      const li = document.createElement("li");
+      li.className = "trend-row";
+
+      const label = document.createElement("span");
+      label.className = "label";
+      label.textContent = metric.label;
+
+      const spark = buildSparkline(series);
+
+      const last = document.createElement("span");
+      last.className = "last";
+      last.textContent = fmt(filtered[filtered.length - 1], metric.suffix);
+
+      const arrow = document.createElement("span");
+      arrow.className = "arrow";
+      const first = filtered[0];
+      const lastVal = filtered[filtered.length - 1];
+      const tolerance = metric.suffix === "%" ? 3 : Math.max(1, Math.abs(first) * 0.05);
+      if (Math.abs(lastVal - first) <= tolerance) {
+        arrow.textContent = "→";
+        arrow.dataset.dir = "flat";
+      } else if ((metric.direction === "high_good" && lastVal > first)
+                 || (metric.direction === "low_good" && lastVal < first)) {
+        arrow.textContent = "↑";
+        arrow.dataset.dir = "up";
+      } else {
+        arrow.textContent = "↓";
+        arrow.dataset.dir = "down";
+      }
+
+      li.append(label, spark, last, arrow);
+      container.appendChild(li);
+    }
+  };
+
+  const renderToday = (today) => {
+    if (!today || !today.matches) {
+      todayBar.hidden = true;
+      return;
+    }
+    todayBar.hidden = false;
+    $("today-matches").textContent = today.matches;
+    $("today-record").textContent = `${today.wins}V ${today.losses}D`;
+    $("today-winrate").textContent = `${today.win_rate}%`;
+    $("today-streak").textContent = today.win_streak;
+    $("today-best").textContent = today.best_score;
+  };
+
+  const render = (data) => {
+    if (!data || !data.last_match) {
+      empty.hidden = false;
+      hero.hidden = true;
+      cats.hidden = true;
+      trendSection.hidden = true;
+      todayBar.hidden = true;
+      return;
+    }
+    empty.hidden = true;
+    hero.hidden = false;
+    cats.hidden = false;
+
+    const last = data.last_match;
+    const avg = data.rolling_avg ?? {};
+
+    $("player-name").textContent = last.player_name ?? "—";
+
+    const result = $("last-result");
+    if (last.won === true) {
+      result.textContent = `V ${last.blue_score ?? 0}-${last.orange_score ?? 0}`;
+      const myScore = last.me_team === 0 ? last.blue_score : last.orange_score;
+      const oppScore = last.me_team === 0 ? last.orange_score : last.blue_score;
+      result.textContent = `V ${myScore}-${oppScore}`;
+      result.dataset.outcome = "win";
+    } else if (last.won === false) {
+      const myScore = last.me_team === 0 ? last.blue_score : last.orange_score;
+      const oppScore = last.me_team === 0 ? last.orange_score : last.blue_score;
+      result.textContent = `D ${myScore}-${oppScore}`;
+      result.dataset.outcome = "loss";
+    } else {
+      result.textContent = `${last.blue_score ?? 0}-${last.orange_score ?? 0}`;
+      result.dataset.outcome = "draw";
+    }
+    $("last-score").textContent = last.score ?? 0;
+    $("last-duration").textContent = last.duration_min ?? 0;
+
+    renderInsights(data.insights);
+    renderRows("cat-pos", POSITIONING_ROWS, last, avg);
+    renderRows("cat-boost", BOOST_ROWS, last, avg);
+    renderRows("cat-mech", MECH_ROWS, last, avg);
+    renderTrend(data.trend);
+    renderToday(data.today);
+  };
+
+  // Initial fetch — covers the case where a user opens /coach with no live game.
+  const fetchCoach = async () => {
+    try {
+      const r = await fetch("/api/coach");
+      if (!r.ok) return;
+      const data = await r.json();
+      render(data);
+    } catch (err) {
+      // Network failure on first load — the WS will refill once connected.
+    }
+  };
+
+  // WebSocket — same protocol/origin as the page, served by the same FastAPI app.
+  let socket;
+  let retryDelay = 500;
+  const connect = () => {
+    const url = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws`;
+    socket = new WebSocket(url);
+    socket.onopen = () => {
+      retryDelay = 500;
+      setConn("connected", "live");
+    };
+    socket.onmessage = (evt) => {
+      let msg;
+      try {
+        msg = JSON.parse(evt.data);
+      } catch {
+        return;
+      }
+      if (!msg || typeof msg !== "object") return;
+      if (msg.type === "coach" && msg.data) render(msg.data);
+    };
+    socket.onclose = () => {
+      setConn("disconnected", "reconectando…");
+      setTimeout(connect, retryDelay);
+      retryDelay = Math.min(retryDelay * 2, 30000);
+    };
+    socket.onerror = () => socket.close();
+  };
+
+  fetchCoach();
+  connect();
+})();

--- a/static/coach.js
+++ b/static/coach.js
@@ -133,12 +133,16 @@
     if (!values || values.length === 0) return svg;
 
     const filtered = values.filter((v) => v !== null && v !== undefined);
-    if (filtered.length === 0) return svg;
+    // A line needs at least two points; sparse series with a single non-null
+    // value would otherwise produce a degenerate path that closes onto itself.
+    if (filtered.length < 2) return svg;
 
     const min = Math.min(...filtered);
     const max = Math.max(...filtered);
+    // `||` is intentional here: when min === max the range is 0 (falsy) and
+    // we want 1 to avoid divide-by-zero. `??` would only fire on null/undefined.
     const range = max - min || 1;
-    const stepX = values.length > 1 ? 100 / (values.length - 1) : 0;
+    const stepX = 100 / (values.length - 1);
 
     const points = values.map((v, i) => {
       if (v === null || v === undefined) return null;
@@ -152,8 +156,10 @@
       .filter(Boolean)
       .join(" ");
 
-    const firstX = (points.findIndex((p) => p !== null) * stepX).toFixed(1);
-    const lastX = ((points.length - 1) * stepX).toFixed(1);
+    const firstNonNull = points.findIndex((p) => p !== null);
+    const lastNonNull = points.length - 1 - [...points].reverse().findIndex((p) => p !== null);
+    const firstX = (firstNonNull * stepX).toFixed(1);
+    const lastX = (lastNonNull * stepX).toFixed(1);
     const areaPath = `${linePath} L${lastX},30 L${firstX},30 Z`;
 
     const area = document.createElementNS(svgNS, "path");
@@ -248,15 +254,12 @@
     $("player-name").textContent = last.player_name ?? "—";
 
     const result = $("last-result");
+    const myScore = last.me_team === 0 ? last.blue_score : last.orange_score;
+    const oppScore = last.me_team === 0 ? last.orange_score : last.blue_score;
     if (last.won === true) {
-      result.textContent = `V ${last.blue_score ?? 0}-${last.orange_score ?? 0}`;
-      const myScore = last.me_team === 0 ? last.blue_score : last.orange_score;
-      const oppScore = last.me_team === 0 ? last.orange_score : last.blue_score;
       result.textContent = `V ${myScore}-${oppScore}`;
       result.dataset.outcome = "win";
     } else if (last.won === false) {
-      const myScore = last.me_team === 0 ? last.blue_score : last.orange_score;
-      const oppScore = last.me_team === 0 ? last.orange_score : last.blue_score;
       result.textContent = `D ${myScore}-${oppScore}`;
       result.dataset.outcome = "loss";
     } else {

--- a/static/index.html
+++ b/static/index.html
@@ -34,16 +34,6 @@
               <span class="label">SCORE</span>
               <span class="val" id="m-score">0</span>
             </div>
-            <div class="big-stat boost">
-              <span class="label">BOOST</span>
-              <span class="val" id="m-boost">0</span>
-              <div class="bar"><div class="fill" id="m-boost-fill"></div></div>
-            </div>
-            <div class="big-stat speed">
-              <span class="label">SPEED</span>
-              <span class="val" id="m-speed">0</span>
-              <div class="bar"><div class="fill" id="m-speed-fill"></div></div>
-            </div>
           </div>
 
           <div class="section">

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -145,33 +145,6 @@ html, body {
   line-height: 1;
 }
 .big-stat.score .val { color: var(--accent); }
-.big-stat.boost .bar {
-  margin-top: 6px;
-  height: 6px;
-  background: var(--bar-empty);
-  border-radius: 3px;
-  overflow: hidden;
-}
-.big-stat.boost .fill {
-  height: 100%;
-  background: var(--accent);
-  width: 0%;
-  transition: width 120ms linear;
-}
-.big-stat.speed .val { color: var(--good); }
-.big-stat.speed .bar {
-  margin-top: 6px;
-  height: 6px;
-  background: var(--bar-empty);
-  border-radius: 3px;
-  overflow: hidden;
-}
-.big-stat.speed .fill {
-  height: 100%;
-  background: var(--good);
-  width: 0%;
-  transition: width 120ms linear;
-}
 
 .grid {
   list-style: none;

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -46,13 +46,6 @@
     $("me-team").style.color = me.team === 0 ? "#1873ff" : me.team === 1 ? "#ff8a1f" : "";
 
     $("m-score").textContent = m.score ?? 0;
-    $("m-boost").textContent = m.boost ?? 0;
-    $("m-boost-fill").style.width = `${Math.max(0, Math.min(100, m.boost ?? 0))}%`;
-
-    const speed = m.speed ?? 0;
-    $("m-speed").textContent = speed;
-    // Supersonic threshold = 22 in API speed units
-    $("m-speed-fill").style.width = `${Math.max(0, Math.min(100, (speed / 22) * 100))}%`;
 
     $("m-goals").textContent = m.goals ?? 0;
     $("m-shots").textContent = m.shots ?? 0;

--- a/storage.py
+++ b/storage.py
@@ -271,6 +271,10 @@ _INSIGHT_DEFS: list[tuple[str, str, str, int, str]] = [
 
 def _row_to_match(row: sqlite3.Row, columns: list[str]) -> dict:
     raw = dict(zip(columns, row))
+    # Defense in depth: the WS / HTTP responses don't need to echo the platform
+    # PrimaryId back. The frontend only uses player_name. If origin checks ever
+    # leak, dropping this here narrows what an attacker can read.
+    raw.pop("player_id", None)
     won = raw.get("won")
     raw["won"] = None if won is None else bool(won)
     shots = raw.get("shots") or 0
@@ -415,8 +419,10 @@ def _generate_insights(last: dict, avg: dict) -> list[str]:
             continue
         diff = float(last_v) - float(avg_v)
         worse_by = -direction * diff  # positive when last is worse than avg
-        abs_avg = abs(avg_v) if avg_v else 1
-        rel = worse_by / abs_avg if abs_avg else 0
+        # Treat avg=0 explicitly so the relative threshold doesn't fire on
+        # every tiny absolute deviation when the baseline is a true zero.
+        abs_avg = abs(avg_v) if avg_v != 0 else 1
+        rel = worse_by / abs_avg
         if worse_by >= INSIGHT_ABS_THRESHOLD or rel >= INSIGHT_REL_THRESHOLD:
             phrase = (
                 f"{label} {round(last_v)}{suffix} (avg {round(avg_v)}{suffix}) — {advice}"

--- a/storage.py
+++ b/storage.py
@@ -4,11 +4,25 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 
 CONFIG_DIR = Path.home() / ".rl-overlay"
 DB_PATH = CONFIG_DIR / "stats.db"
 CONFIG_PATH = CONFIG_DIR / "config.json"
+
+# Rolling-average window used by /coach. Tuned so a single off-day won't
+# dominate the average and so insights are stable across short sessions.
+COACH_ROLLING_WINDOW = 20
+# Minimum sample size before insights are generated. Below this the rolling
+# average is too noisy to give actionable feedback.
+COACH_INSIGHT_MIN_SAMPLES = 5
+# Trend window in days (inclusive of today).
+COACH_TREND_DAYS = 14
+# Insight thresholds — flag a metric when last-match deviates from rolling
+# avg by ≥ this much (relative) OR by ≥ this many absolute points.
+INSIGHT_REL_THRESHOLD = 0.25
+INSIGHT_ABS_THRESHOLD = 8
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS matches (
@@ -39,15 +53,37 @@ CREATE TABLE IF NOT EXISTS matches (
     avg_shot_power REAL DEFAULT 0,
     boost_wasted_pct REAL DEFAULT 0,
     possession_pct REAL DEFAULT 0,
+    score_per_min INTEGER DEFAULT 0,
+    time_def_third_pct REAL,
+    time_off_third_pct REAL,
+    behind_ball_pct REAL,
+    last_back_pct REAL,
+    dist_to_ball_avg REAL,
+    big_pads INTEGER DEFAULT 0,
+    small_pads INTEGER DEFAULT 0,
+    boost_stolen INTEGER DEFAULT 0,
+    aerial_touches INTEGER DEFAULT 0,
+    fast_aerials INTEGER DEFAULT 0,
     UNIQUE(match_guid, player_id)
 );
 """
 
-_NEW_COLUMNS = [
+_NEW_COLUMNS: list[tuple[str, str]] = [
     ("ball_hits", "INTEGER DEFAULT 0"),
     ("avg_shot_power", "REAL DEFAULT 0"),
     ("boost_wasted_pct", "REAL DEFAULT 0"),
     ("possession_pct", "REAL DEFAULT 0"),
+    ("score_per_min", "INTEGER DEFAULT 0"),
+    ("time_def_third_pct", "REAL"),
+    ("time_off_third_pct", "REAL"),
+    ("behind_ball_pct", "REAL"),
+    ("last_back_pct", "REAL"),
+    ("dist_to_ball_avg", "REAL"),
+    ("big_pads", "INTEGER DEFAULT 0"),
+    ("small_pads", "INTEGER DEFAULT 0"),
+    ("boost_stolen", "INTEGER DEFAULT 0"),
+    ("aerial_touches", "INTEGER DEFAULT 0"),
+    ("fast_aerials", "INTEGER DEFAULT 0"),
 ]
 
 
@@ -88,8 +124,14 @@ def save_match(conn: sqlite3.Connection, snapshot: dict) -> bool:
             blue_score, orange_score, me_team, won,
             score, goals, shots, saves, assists, demos, demos_taken, touches,
             boost_avg, time_zero_boost_pct, time_supersonic_pct, time_airborne_pct,
-            hardest_hit, ball_hits, avg_shot_power, boost_wasted_pct, possession_pct
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            hardest_hit, ball_hits, avg_shot_power, boost_wasted_pct, possession_pct,
+            score_per_min, time_def_third_pct, time_off_third_pct, behind_ball_pct,
+            last_back_pct, dist_to_ball_avg, big_pads, small_pads, boost_stolen,
+            aerial_touches, fast_aerials
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
         """,
         (
             snapshot["match_guid"],
@@ -118,6 +160,17 @@ def save_match(conn: sqlite3.Connection, snapshot: dict) -> bool:
             snapshot.get("avg_shot_power", 0),
             snapshot.get("boost_wasted_pct", 0),
             snapshot.get("possession_pct", 0),
+            snapshot.get("score_per_min", 0),
+            snapshot.get("time_def_third_pct"),
+            snapshot.get("time_off_third_pct"),
+            snapshot.get("behind_ball_pct"),
+            snapshot.get("last_back_pct"),
+            snapshot.get("dist_to_ball_avg"),
+            snapshot.get("big_pads", 0),
+            snapshot.get("small_pads", 0),
+            snapshot.get("boost_stolen", 0),
+            snapshot.get("aerial_touches", 0),
+            snapshot.get("fast_aerials", 0),
         ),
     )
     conn.commit()
@@ -198,6 +251,199 @@ def _current_win_streak(conn: sqlite3.Connection, player_id: str) -> int:
         else:
             break
     return streak
+
+
+# ── Coach view ───────────────────────────────────────────────────────────────
+
+
+# Insight definitions: (key, label, suffix, direction, advice).
+# direction: +1 = high is good (worse when below avg). -1 = low is good (worse when above avg).
+_INSIGHT_DEFS: list[tuple[str, str, str, int, str]] = [
+    ("shot_accuracy", "Shot accuracy", "%", 1, "más tiros con calma"),
+    ("possession_pct", "Posesión", "%", 1, "luchá más por la pelota"),
+    ("score_per_min", "Score/min", "", 1, "busca acciones de impacto"),
+    ("behind_ball_pct", "Detrás del balón", "%", 1, "estás sobreextendido"),
+    ("time_zero_boost_pct", "Sin boost", "%", -1, "recoge más pads"),
+    ("boost_wasted_pct", "Boost wasted", "%", -1, "no recargues con >50"),
+    ("aerial_touches", "Toques aéreos", "", 1, "atrévete a ir arriba"),
+]
+
+
+def _row_to_match(row: sqlite3.Row, columns: list[str]) -> dict:
+    raw = dict(zip(columns, row))
+    won = raw.get("won")
+    raw["won"] = None if won is None else bool(won)
+    shots = raw.get("shots") or 0
+    goals = raw.get("goals") or 0
+    raw["shot_accuracy"] = round(100 * goals / shots) if shots else 0
+    ball_hits = raw.get("ball_hits") or 0
+    aerial_touches = raw.get("aerial_touches") or 0
+    raw["air_touch_pct"] = round(100 * aerial_touches / ball_hits) if ball_hits else 0
+    raw["duration_min"] = _duration_minutes(raw.get("started_at"), raw.get("ended_at"))
+    return raw
+
+
+def _duration_minutes(started_at: str | None, ended_at: str | None) -> int:
+    if not started_at or not ended_at:
+        return 0
+    try:
+        s = datetime.fromisoformat(started_at)
+        e = datetime.fromisoformat(ended_at)
+    except ValueError:
+        return 0
+    delta = (e - s).total_seconds() / 60
+    return max(0, round(delta))
+
+
+def _last_match(conn: sqlite3.Connection, player_id: str) -> dict | None:
+    cur = conn.execute(
+        "SELECT * FROM matches WHERE player_id = ? ORDER BY ended_at DESC LIMIT 1",
+        (player_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    columns = [c[0] for c in cur.description]
+    return _row_to_match(row, columns)
+
+
+def _rolling_avg(
+    conn: sqlite3.Connection,
+    player_id: str,
+    exclude_id: int | None,
+    window: int = COACH_ROLLING_WINDOW,
+) -> dict:
+    cur = conn.execute(
+        """
+        SELECT
+            COUNT(*) AS count,
+            AVG(score) AS score,
+            AVG(goals) AS goals,
+            AVG(shots) AS shots,
+            AVG(saves) AS saves,
+            AVG(assists) AS assists,
+            AVG(score_per_min) AS score_per_min,
+            AVG(possession_pct) AS possession_pct,
+            AVG(boost_avg) AS boost_avg,
+            AVG(boost_wasted_pct) AS boost_wasted_pct,
+            AVG(time_zero_boost_pct) AS time_zero_boost_pct,
+            AVG(time_supersonic_pct) AS time_supersonic_pct,
+            AVG(time_airborne_pct) AS time_airborne_pct,
+            AVG(time_def_third_pct) AS time_def_third_pct,
+            AVG(time_off_third_pct) AS time_off_third_pct,
+            AVG(behind_ball_pct) AS behind_ball_pct,
+            AVG(last_back_pct) AS last_back_pct,
+            AVG(dist_to_ball_avg) AS dist_to_ball_avg,
+            AVG(big_pads) AS big_pads,
+            AVG(small_pads) AS small_pads,
+            AVG(boost_stolen) AS boost_stolen,
+            AVG(aerial_touches) AS aerial_touches,
+            AVG(fast_aerials) AS fast_aerials,
+            AVG(ball_hits) AS ball_hits
+        FROM (
+            SELECT * FROM matches
+            WHERE player_id = ?
+              AND (? IS NULL OR id != ?)
+            ORDER BY ended_at DESC
+            LIMIT ?
+        )
+        """,
+        (player_id, exclude_id, exclude_id, window),
+    )
+    row = cur.fetchone()
+    columns = [c[0] for c in cur.description]
+    raw = dict(zip(columns, row))
+    avg = {k: (round(v, 2) if isinstance(v, (int, float)) else v) for k, v in raw.items()}
+    # Synthesize shot_accuracy and air_touch_pct from the underlying averages
+    shots_avg = raw.get("shots") or 0
+    goals_avg = raw.get("goals") or 0
+    avg["shot_accuracy"] = round(100 * goals_avg / shots_avg) if shots_avg else 0
+    ball_hits_avg = raw.get("ball_hits") or 0
+    aerial_avg = raw.get("aerial_touches") or 0
+    avg["air_touch_pct"] = round(100 * aerial_avg / ball_hits_avg) if ball_hits_avg else 0
+    return avg
+
+
+def _trend_by_day(
+    conn: sqlite3.Connection, player_id: str, days: int = COACH_TREND_DAYS
+) -> list[dict]:
+    cur = conn.execute(
+        """
+        SELECT
+            date(started_at, 'localtime') AS day,
+            COUNT(*) AS matches,
+            COALESCE(SUM(CASE WHEN won = 1 THEN 1 ELSE 0 END), 0) AS wins,
+            COALESCE(SUM(goals), 0) AS goals,
+            COALESCE(SUM(shots), 0) AS shots,
+            AVG(score_per_min) AS score_per_min,
+            AVG(behind_ball_pct) AS behind_ball_pct,
+            AVG(possession_pct) AS possession_pct
+        FROM matches
+        WHERE player_id = ?
+          AND date(started_at, 'localtime') >= date('now', 'localtime', ?)
+        GROUP BY day
+        ORDER BY day ASC
+        """,
+        (player_id, f"-{days - 1} days"),
+    )
+    out: list[dict] = []
+    for row in cur.fetchall():
+        day, matches, wins, goals, shots, spm, bbp, poss = row
+        out.append({
+            "day": day,
+            "matches": matches,
+            "win_rate": round(100 * wins / matches) if matches else 0,
+            "shot_accuracy": round(100 * goals / shots) if shots else 0,
+            "score_per_min": round(spm) if spm is not None else 0,
+            "behind_ball_pct": round(bbp) if bbp is not None else None,
+            "possession_pct": round(poss) if poss is not None else None,
+        })
+    return out
+
+
+def _generate_insights(last: dict, avg: dict) -> list[str]:
+    """Return up to 3 actionable phrases comparing the latest match against the rolling avg.
+
+    Only flags metrics where last is *worse* than avg by enough magnitude to be
+    meaningful (relative ≥ INSIGHT_REL_THRESHOLD or absolute ≥ INSIGHT_ABS_THRESHOLD).
+    """
+    candidates: list[tuple[float, str]] = []
+    for key, label, suffix, direction, advice in _INSIGHT_DEFS:
+        last_v = last.get(key)
+        avg_v = avg.get(key)
+        if last_v is None or avg_v is None:
+            continue
+        diff = float(last_v) - float(avg_v)
+        worse_by = -direction * diff  # positive when last is worse than avg
+        abs_avg = abs(avg_v) if avg_v else 1
+        rel = worse_by / abs_avg if abs_avg else 0
+        if worse_by >= INSIGHT_ABS_THRESHOLD or rel >= INSIGHT_REL_THRESHOLD:
+            phrase = (
+                f"{label} {round(last_v)}{suffix} (avg {round(avg_v)}{suffix}) — {advice}"
+            )
+            candidates.append((worse_by, phrase))
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return [phrase for _, phrase in candidates[:3]]
+
+
+def coach_stats(conn: sqlite3.Connection, player_id: str) -> dict:
+    last = _last_match(conn, player_id)
+    exclude_id = last["id"] if last else None
+    avg = _rolling_avg(conn, player_id, exclude_id)
+    trend = _trend_by_day(conn, player_id)
+    rolling_count = avg.get("count") or 0
+    insights = (
+        _generate_insights(last, avg)
+        if last and rolling_count >= COACH_INSIGHT_MIN_SAMPLES
+        else []
+    )
+    return {
+        "last_match": last,
+        "rolling_avg": avg,
+        "trend": trend,
+        "insights": insights,
+        "today": today_stats(conn, player_id),
+    }
 
 
 def load_config() -> dict:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -317,3 +317,96 @@ def test_match_ended_broadcasts_today_even_without_identity(fresh_state):
     cached = json.loads(app.hub._latest["today"])
     assert cached["type"] == "today"
     assert cached["data"] == app.EMPTY_TODAY
+
+
+# ── Coach broadcast and endpoint ────────────────────────────────────────────
+
+
+def test_match_ended_broadcasts_coach(fresh_state):
+    """MatchEnded should also publish a 'coach' payload so /coach refreshes live."""
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({
+        "Event": "UpdateState",
+        "Data": {
+            "MatchGuid": "M1",
+            "Players": [{"Name": "alas", "PrimaryId": "Steam|1|0", "TeamNum": 0,
+                         "Score": 250, "Goals": 1, "Shots": 2, "Saves": 0,
+                         "Assists": 0, "Demos": 0, "Touches": 5, "Boost": 50,
+                         "Speed": 0, "bOnGround": True, "bHasCar": True}],
+            "Game": {"Teams": [{"TeamNum": 0, "Score": 1}, {"TeamNum": 1, "Score": 0}],
+                     "TimeSeconds": 0, "bOvertime": False, "bReplay": False,
+                     "Arena": "stadium", "bHasTarget": False},
+        },
+    })
+    app.handle_event({"Event": "MatchEnded", "Data": {"MatchGuid": "M1"}})
+
+    cached = json.loads(app.hub._latest["coach"])
+    assert cached["type"] == "coach"
+    # The just-saved match should be the last_match in the coach payload
+    assert cached["data"]["last_match"]["match_guid"] == "M1"
+
+
+def test_match_guid_change_broadcasts_coach(fresh_state):
+    """Mid-stream match rotation also refreshes the coach payload."""
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+
+    def state(guid):
+        return {
+            "Event": "UpdateState",
+            "Data": {
+                "MatchGuid": guid,
+                "Players": [{"Name": "alas", "PrimaryId": "Steam|1|0", "TeamNum": 0,
+                             "Score": 100, "Goals": 0, "Shots": 0, "Saves": 0,
+                             "Assists": 0, "Demos": 0, "Touches": 0, "Boost": 50,
+                             "Speed": 0, "bOnGround": True, "bHasCar": True}],
+                "Game": {"Teams": [{"TeamNum": 0, "Score": 0}, {"TeamNum": 1, "Score": 0}],
+                         "TimeSeconds": 290, "bOvertime": False, "bReplay": False,
+                         "Arena": "stadium", "bHasTarget": False},
+            },
+        }
+
+    app.handle_event(state("MATCH_A"))
+    app.handle_event(state("MATCH_B"))  # rotation triggers coach broadcast
+
+    assert "coach" in app.hub._latest
+
+
+def test_api_coach_returns_empty_when_no_identity(fresh_state):
+    app.agg.me_id = None
+    result = asyncio.run(app.api_coach())
+    assert result == app.EMPTY_COACH
+
+
+def test_api_coach_returns_data_when_identity_known(fresh_state):
+    """With an identity and saved matches, /api/coach returns the coach view."""
+    from datetime import datetime
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    today_iso = datetime.now().astimezone().isoformat()
+    app.db.execute(
+        "INSERT INTO matches (match_guid, player_id, started_at, ended_at, won, "
+        "score, goals, shots) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("M1", "Steam|1|0", today_iso, today_iso, 1, 300, 1, 2),
+    )
+    app.db.commit()
+
+    result = asyncio.run(app.api_coach())
+    assert result["last_match"]["match_guid"] == "M1"
+    assert result["today"]["matches"] == 1
+
+
+def test_hub_caches_coach_payload_for_late_subscribers():
+    """A client connecting after a coach payload was published must receive it."""
+    # Earlier asyncio.run() calls in this file close the default loop. On 3.9
+    # asyncio.Queue() needs a current loop at construction time — install a
+    # fresh one before subscribing.
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    hub = app.Hub()
+    hub.publish({"type": "coach", "data": {"last_match": None, "insights": []}})
+
+    queue = hub.subscribe()
+    received = []
+    while not queue.empty():
+        received.append(json.loads(queue.get_nowait()))
+
+    assert any(m["type"] == "coach" for m in received)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -86,9 +86,25 @@ def test_origin_allowed_loopback_and_obs():
     assert app._origin_allowed(None) is True
 
 
+def test_origin_allowed_any_port_on_loopback():
+    """The user picks --port at runtime; the WS check must follow."""
+    assert app._origin_allowed("http://127.0.0.1:8765") is True
+    assert app._origin_allowed("http://127.0.0.1:3000") is True
+    assert app._origin_allowed("http://localhost:9999") is True
+    assert app._origin_allowed("http://[::1]:8080") is True
+
+
 def test_origin_allowed_rejects_external():
     assert app._origin_allowed("https://evil.example.com") is False
     assert app._origin_allowed("http://192.168.1.10:8080") is False
+    # LAN addresses must stay rejected even on the default port
+    assert app._origin_allowed("http://10.0.0.5:8080") is False
+
+
+def test_origin_allowed_rejects_malformed_or_unknown_scheme():
+    assert app._origin_allowed("not-a-url") is False
+    assert app._origin_allowed("file:///etc/passwd") is False
+    assert app._origin_allowed("javascript:alert(1)") is False
 
 
 # ── handle_event ─────────────────────────────────────────────────────────────

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,9 +81,15 @@ def test_hub_unsubscribe_stops_delivery():
 def test_origin_allowed_loopback_and_obs():
     assert app._origin_allowed("http://127.0.0.1:8080") is True
     assert app._origin_allowed("http://localhost:8080") is True
-    assert app._origin_allowed("null") is True
     # OBS Browser Source omits the header entirely
     assert app._origin_allowed(None) is True
+
+
+def test_origin_null_rejected():
+    """Sandboxed iframes (`<iframe sandbox>`) and data:/blob: contexts send
+    `Origin: null`. Any external site can mint such a context, so the WS must
+    NOT trust it — only the absence of an Origin header (OBS) is allowed."""
+    assert app._origin_allowed("null") is False
 
 
 def test_origin_allowed_any_port_on_loopback():
@@ -99,6 +105,12 @@ def test_origin_allowed_rejects_external():
     assert app._origin_allowed("http://192.168.1.10:8080") is False
     # LAN addresses must stay rejected even on the default port
     assert app._origin_allowed("http://10.0.0.5:8080") is False
+
+
+def test_origin_allowed_rejects_lookalike_subdomains():
+    """Hostname tail-attacks: `127.0.0.1.evil.com` must NOT match `127.0.0.1`."""
+    assert app._origin_allowed("http://127.0.0.1.evil.com") is False
+    assert app._origin_allowed("http://localhost.evil.com") is False
 
 
 def test_origin_allowed_rejects_malformed_or_unknown_scheme():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -290,3 +290,319 @@ def test_first_event_without_initialized_still_inits_match():
     assert agg.match_guid == "M1"
     assert agg.started_at is not None
     assert agg.frames == 1
+
+
+# ── Positioning ─────────────────────────────────────────────────────────────
+
+
+def make_state_with_locations(
+    *, me_y, ball_y, me_team=0, me_x=0.0, me_z=17.0,
+    ball_x=0.0, ball_z=90.0, teammate_y=None,
+):
+    """Build an UpdateState with Location data for both player and ball."""
+    me = {
+        "Name": "alas", "PrimaryId": "Steam|1|0", "TeamNum": me_team,
+        "Score": 100, "Goals": 0, "Shots": 0, "Saves": 0, "Assists": 0,
+        "Demos": 0, "Touches": 0, "Boost": 50, "Speed": 0,
+        "bOnGround": True, "bHasCar": True,
+        "Location": {"X": me_x, "Y": me_y, "Z": me_z},
+    }
+    players = [me]
+    if teammate_y is not None:
+        players.append({
+            "Name": "kuxir", "PrimaryId": "Steam|2|0", "TeamNum": me_team,
+            "Score": 0, "Goals": 0, "Shots": 0, "Saves": 0, "Assists": 0,
+            "Demos": 0, "Touches": 0, "Boost": 50, "Speed": 0,
+            "bOnGround": True, "bHasCar": True,
+            "Location": {"X": 1500.0, "Y": teammate_y, "Z": 17.0},
+        })
+    return {
+        "MatchGuid": "M1",
+        "Players": players,
+        "Game": {
+            "Teams": [{"TeamNum": 0, "Score": 0}, {"TeamNum": 1, "Score": 0}],
+            "TimeSeconds": 240, "bOvertime": False, "bReplay": False,
+            "Arena": "stadium", "bHasTarget": False,
+            "Ball": {"Speed": 0, "Location": {"X": ball_x, "Y": ball_y, "Z": ball_z}},
+        },
+    }
+
+
+def test_positioning_def_off_thirds_for_blue_team():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0  # Blue defends -Y
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # Blue team — defensive third is Y < -2000, offensive Y > 2000
+    for me_y in (-3000, -3000, 0, 3000):  # 2 def, 1 mid, 1 off
+        agg.on_update_state(make_state_with_locations(me_y=me_y, ball_y=0))
+
+    assert agg.frames_pos == 4
+    assert agg.time_def_third_pct() == 50
+    assert agg.time_off_third_pct() == 25
+    assert agg.time_mid_third_pct() == 25
+
+
+def test_positioning_mirrors_for_orange_team():
+    """Orange defends +Y, so Y=+3000 should count as defensive for them."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 1
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    for me_y in (3000, 3000, 0, -3000):
+        agg.on_update_state(make_state_with_locations(me_y=me_y, ball_y=0, me_team=1))
+
+    assert agg.time_def_third_pct() == 50
+    assert agg.time_off_third_pct() == 25
+
+
+def test_behind_ball_pct():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # Blue team: "behind ball" means me_y < ball_y (more negative = more defensive)
+    for me_y, ball_y in ((-3000, -1000), (-2000, -1000), (1000, 0), (-500, 500)):
+        agg.on_update_state(make_state_with_locations(me_y=me_y, ball_y=ball_y))
+
+    # 3 of 4 frames have me_y < ball_y
+    assert agg.behind_ball_pct() == 75
+
+
+def test_dist_to_ball_avg():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # Place me at (0,0,0) and ball at (0, dist, 0) so dist == |dy|
+    for dist in (1000, 2000, 3000):
+        agg.on_update_state(make_state_with_locations(
+            me_y=0, ball_y=dist, me_z=0, ball_z=0,
+        ))
+
+    assert agg.dist_to_ball_avg() == 2000
+
+
+def test_last_back_pct_with_teammate():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # me deeper than teammate → last back
+    agg.on_update_state(make_state_with_locations(me_y=-3000, ball_y=0, teammate_y=-1000))
+    # teammate deeper than me → not last back
+    agg.on_update_state(make_state_with_locations(me_y=-1000, ball_y=0, teammate_y=-3000))
+
+    assert agg.last_back_pct() == 50
+
+
+def test_positioning_unchanged_when_no_location():
+    """If the API doesn't expose Location, positioning counters stay at zero
+    and pct accessors return 0 rather than crashing."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    for _ in range(5):
+        agg.on_update_state(make_state())  # no Location field
+
+    assert agg.frames_pos == 0
+    assert agg.time_def_third_pct() == 0
+    assert agg.behind_ball_pct() == 0
+    assert agg.has_positioning_data() is False
+
+
+# ── Boost pickup detection ──────────────────────────────────────────────────
+
+
+def test_big_pad_detected_from_zero_to_full_boost():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # 0 → 100 jump qualifies as big pad pickup
+    agg.on_update_state(make_state(me_boost=0))
+    agg.on_update_state(make_state(me_boost=100))
+    assert agg.big_pads == 1
+    assert agg.small_pads == 0
+
+
+def test_small_pad_detected_from_modest_increment():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # 50 → 62 (delta 12) qualifies as small pad
+    agg.on_update_state(make_state(me_boost=50))
+    agg.on_update_state(make_state(me_boost=62))
+    assert agg.small_pads == 1
+    assert agg.big_pads == 0
+
+
+def test_no_pad_for_natural_consumption():
+    """Decreasing boost (consumption) must not be classified as a pickup."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    for boost in (100, 80, 60, 40, 20, 0):
+        agg.on_update_state(make_state(me_boost=boost))
+
+    assert agg.big_pads == 0
+    assert agg.small_pads == 0
+
+
+def test_boost_stolen_detected_in_opponent_half():
+    """A pickup at Y > 0 (after team mirror) is counted as stolen."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # Pickup in own half (Y < 0): not stolen.
+    # First frame seeds prev_boost=10, second frame jumps to 100 → big pad.
+    s_low = make_state_with_locations(me_y=-1000, ball_y=0)
+    s_low["Players"][0]["Boost"] = 10
+    agg.on_update_state(s_low)
+    s_full = make_state_with_locations(me_y=-1000, ball_y=0)
+    s_full["Players"][0]["Boost"] = 100
+    agg.on_update_state(s_full)
+    assert agg.big_pads == 1
+    assert agg.boost_stolen == 0
+
+    # Pickup in opponent half: stolen.
+    s2 = make_state_with_locations(me_y=2000, ball_y=0)
+    s2["Players"][0]["Boost"] = 5
+    agg.on_update_state(s2)
+    s3 = make_state_with_locations(me_y=2000, ball_y=0)
+    s3["Players"][0]["Boost"] = 100
+    agg.on_update_state(s3)
+    assert agg.boost_stolen == 1
+
+
+# ── Aerials ─────────────────────────────────────────────────────────────────
+
+
+def test_aerial_touch_counted_when_ball_hit_while_airborne():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+
+    # First frame establishes me as airborne
+    agg.on_update_state(make_state(me_on_ground=False))
+    agg.on_ball_hit({
+        "Players": [{"Name": "alas", "TeamNum": 0}],
+        "Ball": {"PostHitSpeed": 80},
+    })
+    assert agg.aerial_touches == 1
+    assert agg.ball_hits == 1
+
+    # Now grounded — next ball hit is not aerial
+    agg.on_update_state(make_state(me_on_ground=True))
+    agg.on_ball_hit({
+        "Players": [{"Name": "alas", "TeamNum": 0}],
+        "Ball": {"PostHitSpeed": 50},
+    })
+    assert agg.aerial_touches == 1
+    assert agg.ball_hits == 2
+
+
+def test_air_touch_pct():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+
+    agg.on_update_state(make_state(me_on_ground=False))
+    for _ in range(3):
+        agg.on_ball_hit({
+            "Players": [{"Name": "alas", "TeamNum": 0}],
+            "Ball": {"PostHitSpeed": 50},
+        })
+    agg.on_update_state(make_state(me_on_ground=True))
+    for _ in range(2):
+        agg.on_ball_hit({
+            "Players": [{"Name": "alas", "TeamNum": 0}],
+            "Ball": {"PostHitSpeed": 50},
+        })
+
+    # 3 aerial of 5 total
+    assert agg.air_touch_pct() == 60
+
+
+def test_fast_aerial_counted_when_takeoff_with_boost_reaches_high_z(monkeypatch):
+    import state as state_module
+    fake_now = [1000.0]
+    monkeypatch.setattr(state_module.time, "monotonic", lambda: fake_now[0])
+
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # On ground with full boost
+    s_ground = make_state_with_locations(me_y=0, ball_y=0, me_z=17.0)
+    s_ground["Players"][0]["Boost"] = 50
+    agg.on_update_state(s_ground)
+
+    # Takeoff
+    fake_now[0] = 1000.5
+    s_air = make_state_with_locations(me_y=0, ball_y=0, me_z=200.0)
+    s_air["Players"][0]["Boost"] = 50
+    s_air["Players"][0]["bOnGround"] = False
+    agg.on_update_state(s_air)
+
+    # Reaches high Z within window
+    fake_now[0] = 1001.5
+    s_high = make_state_with_locations(me_y=0, ball_y=0, me_z=900.0)
+    s_high["Players"][0]["Boost"] = 30
+    s_high["Players"][0]["bOnGround"] = False
+    agg.on_update_state(s_high)
+
+    assert agg.fast_aerials == 1
+
+
+def test_fast_aerial_not_counted_when_takeoff_boost_too_low(monkeypatch):
+    import state as state_module
+    fake_now = [1000.0]
+    monkeypatch.setattr(state_module.time, "monotonic", lambda: fake_now[0])
+
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    s_ground = make_state_with_locations(me_y=0, ball_y=0, me_z=17.0)
+    s_ground["Players"][0]["Boost"] = 10  # below FAST_AERIAL_BOOST_MIN
+    agg.on_update_state(s_ground)
+
+    fake_now[0] = 1000.5
+    s_air = make_state_with_locations(me_y=0, ball_y=0, me_z=900.0)
+    s_air["Players"][0]["Boost"] = 5
+    s_air["Players"][0]["bOnGround"] = False
+    agg.on_update_state(s_air)
+
+    assert agg.fast_aerials == 0
+
+
+# ── DB snapshot exposes new fields ──────────────────────────────────────────
+
+
+def test_db_snapshot_includes_new_fields():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.me_team = 0
+    agg.on_initialized({"MatchGuid": "M1"})
+    agg.on_update_state(make_state_with_locations(me_y=-3000, ball_y=0))
+
+    snap = agg.to_db_snapshot()
+    assert "time_def_third_pct" in snap
+    assert "behind_ball_pct" in snap
+    assert "big_pads" in snap
+    assert "aerial_touches" in snap
+    assert "fast_aerials" in snap
+    assert "score_per_min" in snap
+    # With Location present, positioning is captured (not None)
+    assert snap["time_def_third_pct"] == 100  # all frames in def third

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -457,6 +457,31 @@ def test_no_pad_for_natural_consumption():
     assert agg.small_pads == 0
 
 
+def test_respawn_does_not_count_as_pad_pickup():
+    """Demolition + respawn sequence: bHasCar flips True→False (death) then
+    False→True with Boost=33 (RL gives 1/3 boost on respawn). The 33-point
+    jump must NOT be counted as a small-pad pickup."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    # Healthy frame at 60 boost
+    agg.on_update_state(make_state(me_boost=60, me_has_car=True))
+    # Demolition: bHasCar=False, Boost=0
+    agg.on_update_state(make_state(me_boost=0, me_has_car=False))
+    # Respawn: bHasCar=True, Boost=33
+    agg.on_update_state(make_state(me_boost=33, me_has_car=True))
+
+    assert agg.demos_taken == 1
+    assert agg.big_pads == 0
+    assert agg.small_pads == 0
+
+    # Real pickup after respawn should still register
+    agg.on_update_state(make_state(me_boost=33, me_has_car=True))
+    agg.on_update_state(make_state(me_boost=45, me_has_car=True))
+    assert agg.small_pads == 1
+
+
 def test_boost_stolen_detected_in_opponent_half():
     """A pickup at Y > 0 (after team mirror) is counted as stolen."""
     agg = MatchAggregator()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from storage import open_db, save_match, today_stats  # noqa: E402
+from storage import coach_stats, open_db, save_match, today_stats  # noqa: E402
 
 
 def make_snapshot(match_guid="M1", won=True, **overrides):
@@ -128,3 +128,170 @@ def test_save_match_rejects_missing_started_at(tmp_path):
     assert save_match(db, snap) is False
     count = db.execute("SELECT COUNT(*) FROM matches").fetchone()[0]
     assert count == 0
+
+
+# ── New columns persistence ─────────────────────────────────────────────────
+
+
+def test_save_match_persists_new_columns(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    snap = make_snapshot(
+        score_per_min=312, time_def_third_pct=32.5, time_off_third_pct=27.0,
+        behind_ball_pct=68.0, last_back_pct=22.0, dist_to_ball_avg=1245.0,
+        big_pads=14, small_pads=38, boost_stolen=3,
+        aerial_touches=9, fast_aerials=2,
+    )
+    save_match(db, snap)
+
+    row = db.execute(
+        "SELECT score_per_min, time_def_third_pct, behind_ball_pct, big_pads, "
+        "aerial_touches, fast_aerials FROM matches WHERE match_guid='M1'"
+    ).fetchone()
+    assert row == (312, 32.5, 68.0, 14, 9, 2)
+
+
+# ── coach_stats ─────────────────────────────────────────────────────────────
+
+
+def test_coach_stats_empty_db_returns_safe_defaults(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    result = coach_stats(db, "Steam|1|0")
+
+    assert result["last_match"] is None
+    assert result["rolling_avg"]["count"] == 0
+    assert result["trend"] == []
+    assert result["insights"] == []
+    # today_stats is also embedded for convenience
+    assert result["today"]["matches"] == 0
+
+
+def test_coach_stats_returns_last_match_only_below_insight_threshold(tmp_path):
+    """With <5 prior matches, no insights should be generated even if the latest
+    is much worse — the rolling average is too noisy to be actionable."""
+    db = open_db(tmp_path / "stats.db")
+    from datetime import datetime, timedelta
+
+    base = datetime.now().astimezone()
+    for i in range(3):
+        save_match(db, make_snapshot(
+            match_guid=f"AVG{i}",
+            started_at=(base - timedelta(hours=i + 2)).isoformat(),
+            ended_at=(base - timedelta(hours=i + 1, minutes=55)).isoformat(),
+            won=True, score=600, goals=3, shots=6, score_per_min=200,
+            possession_pct=60, behind_ball_pct=60,
+        ))
+    # Latest match is much worse
+    save_match(db, make_snapshot(
+        match_guid="LATEST",
+        started_at=base.isoformat(),
+        ended_at=(base + timedelta(minutes=5)).isoformat(),
+        won=False, score=200, goals=0, shots=10, score_per_min=80,
+        possession_pct=30, behind_ball_pct=20,
+    ))
+
+    result = coach_stats(db, "Steam|1|0")
+    assert result["last_match"]["match_guid"] == "LATEST"
+    assert result["rolling_avg"]["count"] == 3
+    assert result["insights"] == []  # below COACH_INSIGHT_MIN_SAMPLES
+
+
+def test_coach_stats_generates_insights_when_last_is_worse(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    from datetime import datetime, timedelta
+
+    base = datetime.now().astimezone()
+    # 6 strong matches as baseline
+    for i in range(6):
+        save_match(db, make_snapshot(
+            match_guid=f"AVG{i}",
+            started_at=(base - timedelta(hours=i + 2)).isoformat(),
+            ended_at=(base - timedelta(hours=i + 1, minutes=55)).isoformat(),
+            won=True, score=600, goals=3, shots=6, score_per_min=300,
+            possession_pct=65, boost_wasted_pct=8, time_zero_boost_pct=5,
+        ))
+    # Latest is much worse on multiple metrics
+    save_match(db, make_snapshot(
+        match_guid="LATEST",
+        started_at=base.isoformat(),
+        ended_at=(base + timedelta(minutes=5)).isoformat(),
+        won=False, score=150, goals=0, shots=10, score_per_min=80,
+        possession_pct=25, boost_wasted_pct=30, time_zero_boost_pct=22,
+    ))
+
+    result = coach_stats(db, "Steam|1|0")
+    assert len(result["insights"]) >= 1
+    # Should mention the most-deviated metric
+    text_blob = " ".join(result["insights"])
+    assert any(
+        phrase in text_blob.lower()
+        for phrase in ["shot accuracy", "posesión", "score/min", "boost wasted", "sin boost"]
+    )
+
+
+def test_coach_stats_rolling_avg_excludes_latest_match(tmp_path):
+    """The rolling avg used for comparison should not include the very match
+    we're comparing against — otherwise deviations get diluted."""
+    db = open_db(tmp_path / "stats.db")
+    from datetime import datetime, timedelta
+
+    base = datetime.now().astimezone()
+    for i in range(3):
+        save_match(db, make_snapshot(
+            match_guid=f"P{i}",
+            started_at=(base - timedelta(hours=i + 2)).isoformat(),
+            ended_at=(base - timedelta(hours=i + 1)).isoformat(),
+            score=300,
+        ))
+    save_match(db, make_snapshot(
+        match_guid="LATEST",
+        started_at=base.isoformat(),
+        ended_at=base.isoformat(),
+        score=900,  # outlier
+    ))
+
+    result = coach_stats(db, "Steam|1|0")
+    # Rolling avg score should be 300 (the 3 prior), not 450 (incl. latest)
+    assert result["rolling_avg"]["score"] == 300
+    assert result["last_match"]["score"] == 900
+
+
+def test_coach_stats_trend_groups_by_local_date(tmp_path):
+    """Trend should bucket matches by date and respect the 14-day window."""
+    db = open_db(tmp_path / "stats.db")
+    from datetime import datetime, timedelta
+
+    today = datetime.now().astimezone()
+    yesterday = today - timedelta(days=1)
+    too_old = today - timedelta(days=20)
+
+    save_match(db, make_snapshot(match_guid="T1", started_at=today.isoformat(),
+                                 ended_at=today.isoformat(), won=True, score_per_min=200))
+    save_match(db, make_snapshot(match_guid="Y1", started_at=yesterday.isoformat(),
+                                 ended_at=yesterday.isoformat(), won=False, score_per_min=150))
+    save_match(db, make_snapshot(match_guid="OLD", started_at=too_old.isoformat(),
+                                 ended_at=too_old.isoformat(), won=True))
+
+    result = coach_stats(db, "Steam|1|0")
+    days_in_trend = [d["day"] for d in result["trend"]]
+    assert today.strftime("%Y-%m-%d") in days_in_trend
+    assert yesterday.strftime("%Y-%m-%d") in days_in_trend
+    assert too_old.strftime("%Y-%m-%d") not in days_in_trend
+
+
+def test_coach_stats_last_match_includes_derived_fields(tmp_path):
+    """last_match should expose shot_accuracy, air_touch_pct, duration_min as
+    convenience fields (computed, not stored)."""
+    db = open_db(tmp_path / "stats.db")
+    save_match(db, make_snapshot(
+        match_guid="DERIVED",
+        goals=4, shots=10,
+        ball_hits=20, aerial_touches=5,
+        started_at="2026-04-30T20:00:00+00:00",
+        ended_at="2026-04-30T20:08:00+00:00",
+    ))
+
+    result = coach_stats(db, "Steam|1|0")
+    last = result["last_match"]
+    assert last["shot_accuracy"] == 40
+    assert last["air_touch_pct"] == 25
+    assert last["duration_min"] == 8


### PR DESCRIPTION
## Summary

Pivota el centro de gravedad del overlay: de gauges en tiempo real (boost / velocidad) hacia **coaching post-partido**. Una sola página `/coach` muestra el último partido, lo compara contra tu promedio móvil de los últimos 20, y resalta las 3 áreas donde más te alejaste de tu propio nivel.

- **3 categorías nuevas de stats** que aún no capturaba el overlay: posicionamiento (tiempo en tercio def/off, % detrás del balón, distancia al balón, % último hombre), boost avanzado (big pads, small pads, boost robado en mitad rival), mecánica (toques aéreos, fast aerials).
- **Insights accionables**: hasta 3 frases generadas comparando el último partido contra el rolling avg, con thresholds de 25% relativo o 8 puntos absolutos. Solo se emiten con ≥5 partidos previos.
- **Tendencia 14 días** con sparklines SVG inline (win rate, score/min, shot acc, % detrás del balón, posesión).
- **Live overlay adelgazado** según pediste: fuera los gauges 0–100 y 0–22; el resto (marcador / reloj / output / ball / boost-avg / movement / combat / today) se mantiene para uso OBS.

## Cambios técnicos clave

- 15 columnas SQLite nuevas vía el mecanismo `_NEW_COLUMNS` ya existente — partidos viejos siguen abriéndose con NULL/0 en los campos nuevos.
- Helper `_norm_y(y, team)` para que el equipo Naranja vea su tercio defensivo en el mismo signo que el Azul (mirror de Y).
- `Hub` cachea ahora 3 tipos de payload (`today` / `coach` / `match`) con orden de replay estable; `MatchEnded` publica `coach` además de `today`.
- Demo pump emite `Location.{X,Y,Z}` para players y ball y varía `bOnGround` así `--demo` ejercita las nuevas métricas.
- Constantes nombradas para los thresholds de detección (`BIG_PAD_DELTA`, `FAST_AERIAL_Z_TARGET`, `FAST_AERIAL_WINDOW_S`) en lugar de magic numbers.

## Test plan

- [x] `pytest tests/` — 81 passed (54 → 81), cobertura 94% global / 97% state.py / 95% storage.py.
- [x] `python app.py --demo --no-browser --port 8765` y abrir http://127.0.0.1:8765/coach: empty state correcto sin partidos, hero + insights + sparklines aparecen tras varios demo matches, WS refresca al terminar partido.
- [ ] Smoke con RL real (Windows): jugar 1 partido casual, confirmar que `/coach` se actualiza al terminar, que las nuevas métricas son razonables (def + mid + off ≈ 100%, behind_ball entre 20–80%) y que el live overlay `/` ya no tiene barras de boost / speed.

## Out of scope (siguientes pasos posibles)

- Split por modo (1s / 2s / 3s) usando `Game.TeamSize`.
- StatfeedEvent (epic save, hat trick, aerial goal, centering pass).
- Comparación contra rango (Tracker Network) — descartado en v1 por riesgo ToS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)