### PR TITLE
i18n(coach): translate dashboard UI to English

### DIFF
--- a/static/coach.html
+++ b/static/coach.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>RL Coach — stats para mejorar</title>
-    <meta name="description" content="Dashboard personal de Rocket League: último partido, posicionamiento, boost y mecánicas vs tu propio promedio." />
+    <title>RL Coach — stats to improve</title>
+    <meta name="description" content="Personal Rocket League dashboard: last match, positioning, boost and mechanics vs your own rolling average." />
     <link rel="stylesheet" href="/static/coach.css" />
   </head>
   <body>
@@ -13,18 +13,18 @@
         <span class="brand">COACH</span>
         <span class="player" id="player-name">—</span>
       </h1>
-      <span class="conn" id="conn" aria-live="polite">conectando…</span>
+      <span class="conn" id="conn" aria-live="polite">connecting…</span>
     </header>
 
     <main class="page-main">
       <section class="empty" id="empty" hidden>
-        <p>Aún no hay partidos registrados.</p>
-        <p class="hint">Inicia Rocket League y juega un partido. Vuelve a esta página al terminar.</p>
+        <p>No matches recorded yet.</p>
+        <p class="hint">Start Rocket League and play a match. Come back here when you're done.</p>
       </section>
 
       <section class="hero" id="hero" hidden aria-labelledby="last-heading">
         <header class="hero-head">
-          <h2 id="last-heading">Último partido</h2>
+          <h2 id="last-heading">Last match</h2>
           <p class="hero-meta">
             <span class="result" id="last-result">—</span>
             <span class="sep" aria-hidden="true">·</span>
@@ -35,21 +35,21 @@
         </header>
         <ul class="insights" id="insights"></ul>
         <p class="insights-empty" id="insights-empty" hidden>
-          Sigue jugando para ver patrones — necesito al menos 5 partidos previos para sugerencias.
+          Keep playing to surface patterns — I need at least 5 prior matches for suggestions.
         </p>
       </section>
 
-      <section class="cats" id="cats" hidden aria-label="Categorías de estadísticas">
+      <section class="cats" id="cats" hidden aria-label="Stat categories">
         <article class="cat">
-          <h2>Posicionamiento</h2>
+          <h2>Positioning</h2>
           <ul class="rows" id="cat-pos"></ul>
         </article>
         <article class="cat">
-          <h2>Boost (avanzado)</h2>
+          <h2>Boost (advanced)</h2>
           <ul class="rows" id="cat-boost"></ul>
         </article>
         <article class="cat">
-          <h2>Mecánica</h2>
+          <h2>Mechanics</h2>
           <ul class="rows" id="cat-mech"></ul>
         </article>
         <article class="cat">
@@ -59,17 +59,17 @@
       </section>
 
       <section class="trend" id="trend-section" hidden aria-labelledby="trend-heading">
-        <h2 id="trend-heading">Tendencia <span class="muted">(últimos 14 días)</span></h2>
+        <h2 id="trend-heading">Trend <span class="muted">(last 14 days)</span></h2>
         <ul class="trend-rows" id="trend-rows"></ul>
       </section>
 
       <section class="today-bar" id="today-bar" hidden aria-labelledby="today-heading">
-        <h2 id="today-heading" class="visually-hidden">Hoy</h2>
-        <span class="today-label">HOY</span>
-        <span><strong id="today-matches">0</strong> partidos</span>
-        <span><strong id="today-record">0V 0D</strong></span>
+        <h2 id="today-heading" class="visually-hidden">Today</h2>
+        <span class="today-label">TODAY</span>
+        <span><strong id="today-matches">0</strong> matches</span>
+        <span><strong id="today-record">0W 0L</strong></span>
         <span><strong id="today-winrate">0%</strong> WR</span>
-        <span><strong id="today-streak">0</strong> racha</span>
+        <span><strong id="today-streak">0</strong> streak</span>
         <span><strong id="today-best">0</strong> best score</span>
       </section>
     </main>

--- a/static/coach.js
+++ b/static/coach.js
@@ -18,28 +18,28 @@
   // Layout: [{key, label, suffix, source: "last_match" | "rolling_avg", direction}]
   // direction: "high_good" / "low_good" / "neutral" — controls the trend arrow color.
   const POSITIONING_ROWS = [
-    { key: "time_def_third_pct", label: "Tercio defensivo", suffix: "%", direction: "neutral" },
-    { key: "time_off_third_pct", label: "Tercio ofensivo", suffix: "%", direction: "neutral" },
-    { key: "behind_ball_pct", label: "Detrás del balón", suffix: "%", direction: "high_good" },
-    { key: "last_back_pct", label: "Último hombre", suffix: "%", direction: "neutral" },
-    { key: "dist_to_ball_avg", label: "Distancia balón", suffix: "", direction: "neutral" },
+    { key: "time_def_third_pct", label: "Defensive third", suffix: "%", direction: "neutral" },
+    { key: "time_off_third_pct", label: "Offensive third", suffix: "%", direction: "neutral" },
+    { key: "behind_ball_pct", label: "Behind ball", suffix: "%", direction: "high_good" },
+    { key: "last_back_pct", label: "Last back", suffix: "%", direction: "neutral" },
+    { key: "dist_to_ball_avg", label: "Ball distance", suffix: "", direction: "neutral" },
   ];
 
   const BOOST_ROWS = [
     { key: "big_pads", label: "Big pads", suffix: "", direction: "high_good" },
     { key: "small_pads", label: "Small pads", suffix: "", direction: "high_good" },
-    { key: "boost_stolen", label: "Robado en mitad rival", suffix: "", direction: "high_good" },
+    { key: "boost_stolen", label: "Stolen in opp half", suffix: "", direction: "high_good" },
     { key: "boost_avg", label: "Avg boost", suffix: "", direction: "high_good" },
     { key: "boost_wasted_pct", label: "Wasted", suffix: "%", direction: "low_good" },
-    { key: "time_zero_boost_pct", label: "Sin boost", suffix: "%", direction: "low_good" },
+    { key: "time_zero_boost_pct", label: "Zero boost", suffix: "%", direction: "low_good" },
   ];
 
   const MECH_ROWS = [
-    { key: "aerial_touches", label: "Toques aéreos", suffix: "", direction: "high_good" },
-    { key: "air_touch_pct", label: "% toques aéreos", suffix: "%", direction: "high_good" },
+    { key: "aerial_touches", label: "Aerial touches", suffix: "", direction: "high_good" },
+    { key: "air_touch_pct", label: "Aerial touch %", suffix: "%", direction: "high_good" },
     { key: "fast_aerials", label: "Fast aerials", suffix: "", direction: "high_good" },
-    { key: "time_supersonic_pct", label: "Supersónico", suffix: "%", direction: "high_good" },
-    { key: "time_airborne_pct", label: "En el aire", suffix: "%", direction: "high_good" },
+    { key: "time_supersonic_pct", label: "Supersonic", suffix: "%", direction: "high_good" },
+    { key: "time_airborne_pct", label: "Airborne", suffix: "%", direction: "high_good" },
     { key: "hardest_hit", label: "Hardest hit", suffix: "", direction: "high_good" },
   ];
 
@@ -59,8 +59,8 @@
     { key: "win_rate", label: "Win rate", suffix: "%", direction: "high_good" },
     { key: "score_per_min", label: "Score/min", suffix: "", direction: "high_good" },
     { key: "shot_accuracy", label: "Shot accuracy", suffix: "%", direction: "high_good" },
-    { key: "behind_ball_pct", label: "Detrás del balón", suffix: "%", direction: "high_good" },
-    { key: "possession_pct", label: "Posesión", suffix: "%", direction: "high_good" },
+    { key: "behind_ball_pct", label: "Behind ball", suffix: "%", direction: "high_good" },
+    { key: "possession_pct", label: "Possession", suffix: "%", direction: "high_good" },
   ];
 
   const fmt = (val, suffix) => {
@@ -241,7 +241,7 @@
     }
     todayBar.hidden = false;
     $("today-matches").textContent = today.matches;
-    $("today-record").textContent = `${today.wins}V ${today.losses}D`;
+    $("today-record").textContent = `${today.wins}W ${today.losses}L`;
     $("today-winrate").textContent = `${today.win_rate}%`;
     $("today-streak").textContent = today.win_streak;
     $("today-best").textContent = today.best_score;
@@ -269,10 +269,10 @@
     const myScore = last.me_team === 0 ? last.blue_score : last.orange_score;
     const oppScore = last.me_team === 0 ? last.orange_score : last.blue_score;
     if (last.won === true) {
-      result.textContent = `V ${myScore}-${oppScore}`;
+      result.textContent = `W ${myScore}-${oppScore}`;
       result.dataset.outcome = "win";
     } else if (last.won === false) {
-      result.textContent = `D ${myScore}-${oppScore}`;
+      result.textContent = `L ${myScore}-${oppScore}`;
       result.dataset.outcome = "loss";
     } else {
       result.textContent = `${last.blue_score ?? 0}-${last.orange_score ?? 0}`;
@@ -323,7 +323,7 @@
       if (msg.type === "coach" && msg.data) render(msg.data);
     };
     socket.onclose = () => {
-      setConn("disconnected", "reconectando…");
+      setConn("disconnected", "reconnecting…");
       setTimeout(connect, retryDelay);
       retryDelay = Math.min(retryDelay * 2, 30000);
     };

--- a/storage.py
+++ b/storage.py
@@ -289,13 +289,13 @@ def _current_win_streak(conn: sqlite3.Connection, player_id: str) -> int:
 # Insight definitions: (key, label, suffix, direction, advice).
 # direction: +1 = high is good (worse when below avg). -1 = low is good (worse when above avg).
 _INSIGHT_DEFS: list[tuple[str, str, str, int, str]] = [
-    ("shot_accuracy", "Shot accuracy", "%", 1, "más tiros con calma"),
-    ("possession_pct", "Posesión", "%", 1, "luchá más por la pelota"),
-    ("score_per_min", "Score/min", "", 1, "busca acciones de impacto"),
-    ("behind_ball_pct", "Detrás del balón", "%", 1, "estás sobreextendido"),
-    ("time_zero_boost_pct", "Sin boost", "%", -1, "recoge más pads"),
-    ("boost_wasted_pct", "Boost wasted", "%", -1, "no recargues con >50"),
-    ("aerial_touches", "Toques aéreos", "", 1, "atrévete a ir arriba"),
+    ("shot_accuracy", "Shot accuracy", "%", 1, "take calmer shots"),
+    ("possession_pct", "Possession", "%", 1, "fight harder for the ball"),
+    ("score_per_min", "Score/min", "", 1, "go for high-impact actions"),
+    ("behind_ball_pct", "Behind ball", "%", 1, "you're overextending"),
+    ("time_zero_boost_pct", "Zero boost", "%", -1, "pick up more pads"),
+    ("boost_wasted_pct", "Boost wasted", "%", -1, "don't refill above 50"),
+    ("aerial_touches", "Aerial touches", "", 1, "take to the air more"),
 ]
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -224,7 +224,7 @@ def test_coach_stats_generates_insights_when_last_is_worse(tmp_path):
     text_blob = " ".join(result["insights"])
     assert any(
         phrase in text_blob.lower()
-        for phrase in ["shot accuracy", "posesión", "score/min", "boost wasted", "sin boost"]
+        for phrase in ["shot accuracy", "possession", "score/min", "boost wasted", "zero boost"]
     )
 
 


### PR DESCRIPTION
Follow-up to #7. Migrates all user-facing strings on \`/coach\` from Spanish to English so the dashboard reads consistently — the new "Highlights" card was already in English and the rest of the page lagged behind.

## What changed
- \`static/coach.html\` — \`lang="en"\`, page title, meta description, section headings (Last match, Positioning, Boost (advanced), Mechanics, Trend, Today), empty/insights copy, today-bar units, aria labels.
- \`static/coach.js\` — translated labels in \`POSITIONING_ROWS\`, \`BOOST_ROWS\`, \`MECH_ROWS\`, \`TREND_METRICS\`; connection states (\`connecting…\`, \`reconnecting…\`); win/loss prefix \`V/D\` → \`W/L\`; today record \`0V 0D\` → \`0W 0L\`.
- \`storage.py\` — \`_INSIGHT_DEFS\`: translated all 7 labels and the actionable-advice copy that ships in coach insights.
- \`tests/test_storage.py\` — updated the assertion that previously matched \`"posesión"\` / \`"sin boost"\` to expect \`"possession"\` / \`"zero boost"\`.

## Out of scope
- The OBS overlay (\`static/index.html\`, \`overlay.{js,css}\`) is untouched — it has separate copy and isn't part of the coach dashboard.
- \`README.md\` is untouched — it's the project intro doc; can be migrated separately if desired.

## Test plan
- [x] \`pytest tests/ -q\` → 115 passing, 0 failing.
- [x] No Spanish strings remain in \`static/coach.*\`, \`storage.py\`, or \`tests/test_storage.py\` (verified by grep).
- [ ] Manual smoke on \`/coach\` once merged: every label reads in English, win/loss badges render \`W 3-1\`/\`L 0-2\`, today bar shows \`2W 1L\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)