### PR TITLE
fix: stop caching stale assets + tri-state connection indicator

### DIFF
--- a/app.py
+++ b/app.py
@@ -395,12 +395,27 @@ app.state.tcp_host = "127.0.0.1"
 app.state.tcp_port = 49123
 app.state.demo = False
 
-app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+# Force browsers to revalidate every asset. ETags/Last-Modified still let the
+# server respond 304 when nothing changed, but the browser can no longer mix
+# a fresh index.html with a stale overlay.js / overlay.css from a prior session
+# — which previously caused a silent JS error that left the dashboard frozen
+# on the "connecting…" placeholder.
+NO_CACHE = "no-cache, must-revalidate"
+
+
+class NoCacheStaticFiles(StaticFiles):
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        response = await super().get_response(path, scope)
+        response.headers["Cache-Control"] = NO_CACHE
+        return response
+
+
+app.mount("/static", NoCacheStaticFiles(directory=STATIC_DIR), name="static")
 
 
 @app.get("/")
 async def index() -> FileResponse:
-    return FileResponse(STATIC_DIR / "index.html")
+    return FileResponse(STATIC_DIR / "index.html", headers={"Cache-Control": NO_CACHE})
 
 
 @app.get("/coach")

--- a/static/index.html
+++ b/static/index.html
@@ -27,7 +27,7 @@
           <option value="supersonic_legend">Supersonic Legend</option>
         </select>
       </label>
-      <span class="conn" id="conn" aria-live="polite">connecting…</span>
+      <span class="conn" id="conn" aria-live="polite" data-state="connecting">connecting…</span>
     </header>
 
     <main class="page-main">

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -119,7 +119,9 @@ button:focus-visible {
   text-transform: uppercase;
 }
 
-.conn[data-state="connected"] { color: var(--good); }
+.conn[data-state="connecting"] { color: var(--muted); }
+.conn[data-state="connected"] { color: var(--warn); }
+.conn[data-state="active"] { color: var(--good); }
 .conn[data-state="disconnected"] { color: var(--bad); }
 
 .rank-picker {

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -17,6 +17,27 @@
     conn.textContent = label;
   };
 
+  // Match snapshots stop arriving when the user is in a menu / queue. Mark the
+  // header as "in match" while they're flowing and fall back to "waiting for
+  // match" if none arrive within MATCH_ACTIVE_TIMEOUT_MS — comfortably above
+  // the 5 s server-side throttle so a normal stream keeps the indicator green.
+  const MATCH_ACTIVE_TIMEOUT_MS = 12000;
+  let matchActiveTimer = null;
+  const markMatchActive = () => {
+    setConn("active", "live · in match");
+    if (matchActiveTimer !== null) clearTimeout(matchActiveTimer);
+    matchActiveTimer = setTimeout(() => {
+      setConn("connected", "live · waiting for match");
+      matchActiveTimer = null;
+    }, MATCH_ACTIVE_TIMEOUT_MS);
+  };
+  const clearMatchActive = () => {
+    if (matchActiveTimer !== null) {
+      clearTimeout(matchActiveTimer);
+      matchActiveTimer = null;
+    }
+  };
+
   // ── Live match render ────────────────────────────────────────────
 
   const ALLOWED_TOUCH = { self: "you", team: "teammate", opp: "opponent", none: null };
@@ -397,7 +418,7 @@
     socket = new WebSocket(url);
     socket.onopen = () => {
       retryDelay = 500;
-      setConn("connected", "live");
+      setConn("connected", "live · waiting for match");
     };
     socket.onmessage = (evt) => {
       let msg;
@@ -407,11 +428,14 @@
         return;
       }
       if (!msg || typeof msg !== "object") return;
-      if (msg.type === "match" && msg.data) renderMatch(msg.data);
-      else if (msg.type === "today" && msg.data) renderToday(msg.data);
+      if (msg.type === "match" && msg.data) {
+        renderMatch(msg.data);
+        markMatchActive();
+      } else if (msg.type === "today" && msg.data) renderToday(msg.data);
       else if (msg.type === "coach" && msg.data) renderCoach(msg.data);
     };
     socket.onclose = () => {
+      clearMatchActive();
       setConn("disconnected", "reconnecting…");
       // Cap at 30s so a dashboard left running through a long server outage
       // doesn't keep hammering once a second after the cap.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -622,3 +622,20 @@ def test_coach_route_redirects_to_root(client):
     resp = client.get("/coach", follow_redirects=False)
     assert resp.status_code == 308
     assert resp.headers["location"] == "/"
+
+
+# ── Cache-Control on shell + assets ──────────────────────────────────────────
+# Stale JS/CSS mixed with a fresh index.html can wedge the dashboard on
+# "connecting…" without any visible error, so we force browsers to revalidate.
+
+
+def test_index_sends_no_cache_header(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "no-cache" in resp.headers.get("cache-control", "")
+
+
+def test_static_asset_sends_no_cache_header(client):
+    resp = client.get("/static/overlay.js")
+    assert resp.status_code == 200
+    assert "no-cache" in resp.headers.get("cache-control", "")


### PR DESCRIPTION
## Summary
Fixes the bug where the dashboard would freeze on `connecting…` after a server restart: the browser was reusing a stale `overlay.js`/`overlay.css` from a prior session against the freshly-served `index.html`, blowing up silently before `socket.onopen` could update the header.

- `Cache-Control: no-cache, must-revalidate` on `/` and every `/static/*` response (via a `NoCacheStaticFiles` subclass). ETag/Last-Modified still allow `304 Not Modified` so we don't push bytes for unchanged files — we just refuse to let the browser skip the round-trip.
- Header indicator is now tri-state: `connecting` (gray) → `live · waiting for match` (yellow) → `live · in match` (green). Active state expires 12 s after the last `match` payload arrives (the server throttles `UpdateState` at 5 s, so 12 s is comfortably above noise) and resets on socket close so a stale "in match" can't survive a disconnect.

## Test plan
- [x] `pytest tests/` — 135 passed (added `test_index_sends_no_cache_header` and `test_static_asset_sends_no_cache_header`).
- [x] `curl -I /` and `curl -I /static/overlay.js` show `cache-control: no-cache, must-revalidate`.
- [x] In demo mode, header transitions through `connecting → live · waiting for match → live · in match` after the snapshot publishes, then drops back to `live · waiting for match` once the 12 s timer expires.
- [ ] Manual: restart server, hard-refresh the browser — confirm no stale-asset wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)