### PR TITLE
fix(tcp): parse RL stats stream as concatenated JSON, not newline-delimited

### DIFF
--- a/app.py
+++ b/app.py
@@ -209,7 +209,7 @@ def handle_event(event: dict) -> None:
     name = event.get("Event")
     data = event.get("Data") or {}
 
-    if name == "Initialized":
+    if name == "MatchInitialized":
         # If a previous match was in progress and never sent MatchEnded, persist
         # it before resetting the aggregator.
         if agg.match_guid:
@@ -220,7 +220,7 @@ def handle_event(event: dict) -> None:
 
     if name == "UpdateState":
         # Same defense for the case where the game rotates MatchGuid without
-        # an Initialized event (e.g. spectator transitions).
+        # a MatchInitialized event (e.g. spectator transitions).
         if agg.is_match_guid_change(data):
             _persist_current_match()
             _broadcast_today()

--- a/tcp_client.py
+++ b/tcp_client.py
@@ -7,34 +7,43 @@ log = logging.getLogger(__name__)
 
 EventHandler = Callable[[dict], Awaitable[None]]
 
-# A single Stats API event fits comfortably under ~10 KB. Cap at 1 MB to bound
-# memory if a misbehaving (or malicious) source on the local TCP port sends
-# data without newlines.
-MAX_LINE_BYTES = 1_000_000
+# Runaway-buffer guard. The Stats API does not document a max event size, but
+# in practice they fit in a few KB. If we accumulate more than this without
+# producing a parsable object, the stream is corrupt — drop and resync.
+MAX_BUFFER_CHARS = 1_000_000
 
 
-def split_json_lines(buffer: bytes) -> tuple[list[dict], bytes]:
-    """Split a TCP buffer into JSON objects, returning leftover bytes.
+def parse_json_objects(
+    buffer: str, decoder: json.JSONDecoder
+) -> tuple[list[dict], str]:
+    """Extract zero or more JSON objects from a string buffer.
 
-    The Stats API emits one JSON object per line, but a TCP read can land
-    in the middle of a line — leftover is kept for the next read.
+    The Stats API streams JSON values separated by arbitrary whitespace
+    (often pretty-printed with embedded newlines), not by a single newline
+    terminator. Splitting on '\\n' would either tear individual objects
+    apart or — with no newlines at all — let the buffer grow until our
+    runaway guard drops it. We use streaming raw_decode instead, matching
+    what the reference clients (manucabral/RocketLeagueStatsAPI in Python,
+    xentrick/rlstatsapi in Rust) do.
+
+    Returns parsed objects and the leftover unparsed tail (a partial
+    object waiting for more bytes from the socket).
     """
     events: list[dict] = []
     while True:
-        nl = buffer.find(b"\n")
-        if nl == -1:
-            if len(buffer) > MAX_LINE_BYTES:
-                log.warning("line buffer exceeded %d bytes without newline — dropping", MAX_LINE_BYTES)
-                return events, b""
-            return events, buffer
-        line = buffer[:nl].strip()
-        buffer = buffer[nl + 1 :]
-        if not line:
-            continue
+        stripped = buffer.lstrip()
+        if not stripped:
+            return events, ""
         try:
-            events.append(json.loads(line))
-        except json.JSONDecodeError as exc:
-            log.warning("invalid JSON line dropped: %s", exc)
+            obj, end = decoder.raw_decode(stripped)
+        except json.JSONDecodeError:
+            # Incomplete object — keep what we have and wait for more bytes.
+            return events, stripped
+        if isinstance(obj, dict):
+            events.append(obj)
+        elif isinstance(obj, list):
+            events.extend(item for item in obj if isinstance(item, dict))
+        buffer = stripped[end:]
 
 
 async def stream_events(
@@ -46,6 +55,7 @@ async def stream_events(
 
     The game closes the socket between matches, so we loop forever.
     """
+    decoder = json.JSONDecoder()
     while True:
         try:
             log.info("connecting to %s:%d", host, port)
@@ -56,17 +66,23 @@ async def stream_events(
             continue
 
         log.info("connected")
-        buffer = b""
+        buffer = ""
         try:
             while True:
                 chunk = await reader.read(4096)
                 if not chunk:
                     log.info("socket closed by game")
                     break
-                buffer += chunk
-                events, buffer = split_json_lines(buffer)
+                buffer += chunk.decode("utf-8", errors="replace")
+                events, buffer = parse_json_objects(buffer, decoder)
                 for event in events:
                     yield event
+                if len(buffer) > MAX_BUFFER_CHARS:
+                    log.warning(
+                        "buffer exceeded %d chars without parsing an object — dropping",
+                        MAX_BUFFER_CHARS,
+                    )
+                    buffer = ""
         except (ConnectionError, asyncio.IncompleteReadError) as exc:
             log.warning("read error: %s", exc)
         finally:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -123,13 +123,13 @@ def test_origin_allowed_rejects_malformed_or_unknown_scheme():
 
 
 def test_handle_initialized_resets_aggregator(fresh_state):
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
     assert app.agg.match_guid == "M1"
 
 
 def test_handle_update_state_broadcasts_match(fresh_state):
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
     app.handle_event({
         "Event": "UpdateState",
         "Data": {
@@ -177,7 +177,7 @@ def test_match_guid_change_persists_prior_match(fresh_state):
 
 def test_match_ended_persists_match(fresh_state):
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
     app.handle_event({
         "Event": "UpdateState",
         "Data": {
@@ -273,7 +273,7 @@ def test_persist_current_match_skips_when_db_missing(fresh_state, monkeypatch):
 def test_tcp_pump_continues_after_handler_error(fresh_state, monkeypatch):
     """A single bad event must not kill the pump task."""
     events = [
-        {"Event": "Initialized", "Data": {"MatchGuid": "M1"}},
+        {"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}},
         {"Event": "UpdateState", "Data": "this is not a dict"},  # malformed
         {"Event": "MatchEnded", "Data": {"MatchGuid": "M1"}},
     ]
@@ -353,7 +353,7 @@ def test_match_ended_broadcasts_today_even_without_identity(fresh_state):
 def test_match_ended_broadcasts_coach(fresh_state):
     """MatchEnded should also publish a 'coach' payload so /coach refreshes live."""
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
     app.handle_event({
         "Event": "UpdateState",
         "Data": {
@@ -446,7 +446,7 @@ def test_hub_caches_coach_payload_for_late_subscribers():
 # T19: handle_event with StatfeedEvent calls agg.on_statfeed_event
 def test_handle_statfeed_event_increments_counter(fresh_state):
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
 
     app.handle_event({
         "Event": "StatfeedEvent",
@@ -464,7 +464,7 @@ def test_handle_statfeed_event_increments_counter(fresh_state):
 def test_handle_statfeed_event_no_broadcast(fresh_state):
     """StatfeedEvent must NOT trigger a match broadcast (no WS noise mid-game)."""
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
 
     # Capture hub state before and after
     before_latest = dict(app.hub._latest)
@@ -487,7 +487,7 @@ def test_handle_statfeed_event_no_broadcast(fresh_state):
 def test_integration_statfeed_persisted_in_coach_stats(fresh_state):
     """A complete match flow with StatfeedEvents results in highlights in coach_stats."""
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
-    app.handle_event({"Event": "Initialized", "Data": {"MatchGuid": "M1"}})
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})
 
     # One UpdateState so started_at is set and player identity confirmed
     app.handle_event({

--- a/tests/test_tcp_client.py
+++ b/tests/test_tcp_client.py
@@ -5,75 +5,85 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from tcp_client import split_json_lines, stream_events  # noqa: E402
+from tcp_client import parse_json_objects, stream_events  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-def test_split_complete_lines():
-    payload = (FIXTURES / "update_state.json").read_text()
-    minified = json.dumps(json.loads(payload))
-    buffer = (minified + "\n" + minified + "\n").encode()
+def _decoder() -> json.JSONDecoder:
+    return json.JSONDecoder()
 
-    events, leftover = split_json_lines(buffer)
 
-    assert len(events) == 2
-    assert leftover == b""
+def test_parse_objects_back_to_back_no_separator():
+    """Two minified objects glued together — what RL actually sends in practice."""
+    a = json.dumps({"Event": "UpdateState", "Data": {"MatchGuid": "A"}})
+    b = json.dumps({"Event": "BallHit", "Data": {"MatchGuid": "A"}})
+
+    events, leftover = parse_json_objects(a + b, _decoder())
+
+    assert leftover == ""
+    assert [e["Event"] for e in events] == ["UpdateState", "BallHit"]
+
+
+def test_parse_objects_with_arbitrary_whitespace():
+    a = json.dumps({"Event": "UpdateState"})
+    b = json.dumps({"Event": "BallHit"})
+
+    events, leftover = parse_json_objects(a + " \n\t " + b + "\n", _decoder())
+
+    assert leftover == ""
+    assert [e["Event"] for e in events] == ["UpdateState", "BallHit"]
+
+
+def test_parse_pretty_printed_object_with_internal_newlines():
+    """The pre-fix code split on \\n, which tore pretty-printed objects apart."""
+    payload = (FIXTURES / "update_state.json").read_text()  # multi-line indented JSON
+
+    events, leftover = parse_json_objects(payload, _decoder())
+
+    assert leftover == ""
+    assert len(events) == 1
     assert events[0]["Event"] == "UpdateState"
     assert events[0]["Data"]["Game"]["Teams"][0]["Name"] == "Blue"
 
 
-def test_split_keeps_partial_tail():
+def test_parse_keeps_partial_tail_for_next_read():
     full = json.dumps({"Event": "UpdateState", "Data": {}})
-    partial = json.dumps({"Event": "BallHit"})[:20]
-    buffer = (full + "\n" + partial).encode()
+    partial_head = '{"Event": "BallH'
 
-    events, leftover = split_json_lines(buffer)
+    events, leftover = parse_json_objects(full + partial_head, _decoder())
 
     assert len(events) == 1
-    assert leftover.decode() == partial
+    assert leftover == partial_head
 
 
-def test_split_drops_invalid_line_but_continues():
-    valid = json.dumps({"Event": "UpdateState", "Data": {}})
-    buffer = (valid + "\n{not json}\n" + valid + "\n").encode()
+def test_parse_top_level_array_is_flattened_into_objects():
+    """The fixtures include a BallHit array; some Stats API entries arrive batched."""
+    payload = (FIXTURES / "ball_hit_array.json").read_text()
 
-    events, leftover = split_json_lines(buffer)
+    events, leftover = parse_json_objects(payload, _decoder())
 
-    assert leftover == b""
+    assert leftover == ""
     assert len(events) == 2
+    assert all(e["Event"] == "BallHit" for e in events)
 
 
-def test_split_skips_empty_lines():
-    valid = json.dumps({"Event": "UpdateState"})
-    buffer = (valid + "\n\n\n" + valid + "\n").encode()
-
-    events, _ = split_json_lines(buffer)
-
-    assert len(events) == 2
-
-
-def test_split_drops_buffer_when_exceeds_max_line_size():
-    """If the source sends a huge blob without a newline, we drop it instead of
-    growing the buffer unbounded."""
-    from tcp_client import MAX_LINE_BYTES
-
-    huge = b"x" * (MAX_LINE_BYTES + 100)
-    events, leftover = split_json_lines(huge)
+def test_parse_returns_no_events_on_pure_whitespace():
+    events, leftover = parse_json_objects("   \n\n  \t  ", _decoder())
 
     assert events == []
-    assert leftover == b""
+    assert leftover == ""
 
 
-def test_stream_events_yields_from_fake_server():
+def test_stream_events_yields_minified_back_to_back():
     sample = {"Event": "UpdateState", "Data": {"MatchGuid": "abc"}}
 
     async def runner():
-        # Spin up a dummy TCP server that emits 3 lines and closes
         async def serve(_reader, writer):
-            for _ in range(3):
-                writer.write((json.dumps(sample) + "\n").encode())
-                await writer.drain()
+            # Three objects with no separator at all — the worst case the old
+            # newline parser failed on silently in production.
+            writer.write((json.dumps(sample) * 3).encode())
+            await writer.drain()
             writer.close()
 
         server = await asyncio.start_server(serve, "127.0.0.1", 0)
@@ -93,3 +103,30 @@ def test_stream_events_yields_from_fake_server():
     assert len(result) == 3
     assert all(e["Event"] == "UpdateState" for e in result)
     assert result[0]["Data"]["MatchGuid"] == "abc"
+
+
+def test_stream_events_yields_pretty_printed():
+    """Real RL traffic is pretty-printed; verify the end-to-end pump handles it."""
+
+    async def runner():
+        async def serve(_reader, writer):
+            payload = (FIXTURES / "update_state.json").read_text()
+            writer.write(payload.encode())
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(serve, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        async with server:
+            received: list[dict] = []
+            agen = stream_events(host="127.0.0.1", port=port, reconnect_delay=0.01)
+            async for event in agen:
+                received.append(event)
+                await agen.aclose()
+                break
+            return received
+
+    result = asyncio.run(runner())
+    assert len(result) == 1
+    assert result[0]["Event"] == "UpdateState"


### PR DESCRIPTION
## Summary

- **Bug 1 (critical):** `tcp_client.split_json_lines` split the TCP stream on `\n`, but the Rocket League Stats API doesn't use newline-delimited JSON. It streams JSON values separated by arbitrary whitespace, and pretty-printed objects contain `\n` _inside_ the object. End result: an established TCP socket to RL but zero events ever reaching the handler — overlay stuck forever on `live · waiting for match`. Replaces the parser with `json.JSONDecoder().raw_decode()`, matching what the reference clients ([manucabral/RocketLeagueStatsAPI](https://github.com/manucabral/RocketLeagueStatsAPI), [xentrick/rlstatsapi](https://github.com/xentrick/rlstatsapi)) do.
- **Bug 2 (medium):** `handle_event` dispatched on `"Initialized"` but the official event name is `"MatchInitialized"` — the dispatch never matched. Test fixtures updated accordingly.
- New parser also flattens top-level JSON arrays into individual events, so batched payloads (per the existing `ball_hit_array.json` fixture) reach the handler one at a time.

## Why the existing tests didn't catch this

The old `test_tcp_client` tests were written assuming the same wrong premise as the parser (newline-delimited, minified objects). They validated a protocol that doesn't exist. New tests cover the actual wire format: concatenated minified objects, arbitrary-whitespace separators, and pretty-printed objects with internal newlines (the regression for the production bug).

## Test plan

- [x] `pytest tests/` — 137 passed
- [ ] On Windows: `BUILD-EXE.bat` → run `dist\rl-overlay.exe` → start RL → enter an online match → header switches to `live · in match` and stats begin updating