### PR TITLE
fix(tcp): decode string-encoded Data field shipped by Stats API

### DIFF
--- a/tcp_client.py
+++ b/tcp_client.py
@@ -13,6 +13,22 @@ EventHandler = Callable[[dict], Awaitable[None]]
 MAX_BUFFER_CHARS = 1_000_000
 
 
+def _decode_data_field(event: dict) -> dict:
+    """RL ships the inner Data payload as a JSON-encoded string, not a nested
+    object — so handlers see e.g. {"Event": "BallHit", "Data": "{...}"}.
+    Decode it once here so the rest of the app can rely on dict semantics.
+    """
+    data = event.get("Data")
+    if isinstance(data, str):
+        try:
+            event["Data"] = json.loads(data)
+        except json.JSONDecodeError:
+            # Leave the string in place; handle_event's exception guard will
+            # drop the malformed event without taking down the pump.
+            pass
+    return event
+
+
 def parse_json_objects(
     buffer: str, decoder: json.JSONDecoder
 ) -> tuple[list[dict], str]:
@@ -40,9 +56,11 @@ def parse_json_objects(
             # Incomplete object — keep what we have and wait for more bytes.
             return events, stripped
         if isinstance(obj, dict):
-            events.append(obj)
+            events.append(_decode_data_field(obj))
         elif isinstance(obj, list):
-            events.extend(item for item in obj if isinstance(item, dict))
+            events.extend(
+                _decode_data_field(item) for item in obj if isinstance(item, dict)
+            )
         buffer = stripped[end:]
 
 

--- a/tests/test_tcp_client.py
+++ b/tests/test_tcp_client.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from tcp_client import parse_json_objects, stream_events  # noqa: E402
+from tcp_client import _decode_data_field, parse_json_objects, stream_events  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -73,6 +73,40 @@ def test_parse_returns_no_events_on_pure_whitespace():
 
     assert events == []
     assert leftover == ""
+
+
+def test_parse_decodes_string_encoded_data_field():
+    """RL wraps the Data payload as a JSON-encoded string, not a nested object."""
+    inner = '{"MatchGuid":"M1","Players":[{"Name":"alas"}]}'
+    raw = json.dumps({"Event": "BallHit", "Data": inner})
+
+    events, leftover = parse_json_objects(raw, _decoder())
+
+    assert leftover == ""
+    assert len(events) == 1
+    assert events[0]["Event"] == "BallHit"
+    # Data must arrive as a dict for the handler chain (data.get(...))
+    assert isinstance(events[0]["Data"], dict)
+    assert events[0]["Data"]["MatchGuid"] == "M1"
+    assert events[0]["Data"]["Players"][0]["Name"] == "alas"
+
+
+def test_decode_data_field_leaves_dict_data_untouched():
+    """Defensive: if a fixture or future RL build sends Data as a real dict,
+    don't try to re-decode it."""
+    event = {"Event": "BallHit", "Data": {"MatchGuid": "M1"}}
+
+    out = _decode_data_field(event)
+
+    assert out["Data"] == {"MatchGuid": "M1"}
+
+
+def test_decode_data_field_leaves_string_in_place_when_inner_invalid():
+    event = {"Event": "BallHit", "Data": "{not json"}
+
+    out = _decode_data_field(event)
+
+    assert out["Data"] == "{not json"
 
 
 def test_stream_events_yields_minified_back_to_back():


### PR DESCRIPTION
## Summary

Follow-up to #12. With the TCP parser fixed, real RL traffic now reaches `handle_event` — and immediately reveals that the wire format wraps the inner payload as a JSON-encoded **string**, not a nested object:

\`\`\`
{"Event": "BallHit", "Data": "{\"MatchGuid\":\"...\",\"Players\":[...]}"}
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              this is a string, not a dict
\`\`\`

The handlers do \`data.get("MatchGuid")\` and crash with \`'str' object has no attribute 'get'\`. The pump's exception guard logs it as a WARNING (silenced by uvicorn's log config) and the overlay stays on \`live · waiting for match\` with the DB unchanged — same external symptom as before, different root cause.

Decodes the \`Data\` field once in \`tcp_client\` before yielding so the rest of the app keeps its dict-based contract. Defensive against the mixed case (Data already a dict, e.g. test fixtures) and against a malformed inner string.

## Test plan

- [x] \`pytest tests/\` — 140 passed
- [ ] On Windows: rebuild the .exe → enter an online match → header switches to \`live · in match\` and stats start updating