### PR TITLE
feat(ui): render live boost/speed/movement and tighten spacing

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -59,6 +59,14 @@
             <span class="label">SCORE</span>
             <span class="val" id="m-score">0</span>
           </div>
+          <div class="big-stat">
+            <span class="label">BOOST</span>
+            <span class="val"><span id="m-boost">0</span><span class="suffix">%</span></span>
+          </div>
+          <div class="big-stat">
+            <span class="label">SPEED</span>
+            <span class="val" id="m-speed">0</span>
+          </div>
         </div>
 
         <div class="live-grids">
@@ -83,6 +91,23 @@
               <li><span class="k">Hardest hit</span><span class="v" id="m-hardest">0</span></li>
               <li><span class="k">Avg shot pwr</span><span class="v" id="m-avg-shot-pwr">0</span></li>
               <li><span class="k">Last touch</span><span class="v" id="m-last-touch">—</span></li>
+            </ul>
+          </div>
+
+          <div class="section">
+            <h3>BOOST</h3>
+            <ul class="grid">
+              <li><span class="k">Avg</span><span class="v" id="m-boost-avg">0</span></li>
+              <li><span class="k">Wasted</span><span class="v" id="m-boost-wasted">0%</span></li>
+              <li><span class="k">Zero boost</span><span class="v" id="m-zero-boost">0%</span></li>
+            </ul>
+          </div>
+
+          <div class="section">
+            <h3>MOVEMENT</h3>
+            <ul class="grid">
+              <li><span class="k">Supersonic</span><span class="v" id="m-supersonic">0%</span></li>
+              <li><span class="k">Airborne</span><span class="v" id="m-airborne">0%</span></li>
             </ul>
           </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,13 @@
         <span class="brand">COACH</span>
         <span class="player" id="player-name">—</span>
       </h1>
+      <div class="header-scoreline" id="header-scoreline" hidden>
+        <span class="team blue">BLUE</span>
+        <span class="num blue" id="ctx-blue-score">0</span>
+        <span class="clock" id="ctx-clock">5:00</span>
+        <span class="num orange" id="ctx-orange-score">0</span>
+        <span class="team orange">ORANGE</span>
+      </div>
       <label class="rank-picker">
         <span class="visually-hidden">Target rank</span>
         <select id="rank-select">
@@ -40,13 +47,6 @@
         <header class="live-head">
           <h2 id="live-heading">Live match</h2>
           <div class="banner" id="banner" hidden></div>
-          <div class="scoreline">
-            <span class="team blue" id="ctx-blue-team">BLUE</span>
-            <span class="num blue" id="ctx-blue-score">0</span>
-            <span class="clock" id="ctx-clock">5:00</span>
-            <span class="num orange" id="ctx-orange-score">0</span>
-            <span class="team orange" id="ctx-orange-team">ORANGE</span>
-          </div>
           <div class="me-line">
             <span id="me-name">—</span>
             <span class="dot"></span>

--- a/static/index.html
+++ b/static/index.html
@@ -51,6 +51,9 @@
             <span id="me-name">—</span>
             <span class="dot"></span>
             <span id="me-team">unknown team</span>
+            <span class="dot"></span>
+            <span class="live-pill"><span class="pill-k">boost</span><span class="pill-v" id="m-boost">0</span><span class="pill-suffix">%</span></span>
+            <span class="live-pill"><span class="pill-k">speed</span><span class="pill-v" id="m-speed">0</span></span>
           </div>
         </header>
 
@@ -58,14 +61,6 @@
           <div class="big-stat score">
             <span class="label">SCORE</span>
             <span class="val" id="m-score">0</span>
-          </div>
-          <div class="big-stat">
-            <span class="label">BOOST</span>
-            <span class="val"><span id="m-boost">0</span><span class="suffix">%</span></span>
-          </div>
-          <div class="big-stat">
-            <span class="label">SPEED</span>
-            <span class="val" id="m-speed">0</span>
           </div>
         </div>
 

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -250,7 +250,9 @@ button:focus-visible {
 
 .me-line {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
+  align-items: baseline;
   gap: var(--space-2);
   color: var(--muted);
   font-size: 0.75rem;
@@ -258,6 +260,29 @@ button:focus-visible {
 }
 .me-line #me-name { color: var(--fg); font-weight: 600; }
 .me-line .dot::before { content: "•"; color: var(--muted); }
+
+.live-pill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+.live-pill .pill-k {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.625rem;
+  font-weight: 700;
+  color: var(--muted);
+}
+.live-pill .pill-v {
+  color: var(--fg);
+  font-weight: 800;
+  font-size: 0.875rem;
+}
+.live-pill .pill-suffix {
+  color: var(--muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+}
 
 .live-grids {
   display: grid;

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -84,7 +84,7 @@ button:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
-  padding: var(--space-4) var(--space-6);
+  padding: var(--space-3) var(--space-5);
   border-bottom: 1px solid var(--border);
   background: var(--bg);
   position: sticky;
@@ -163,15 +163,15 @@ button:focus-visible {
 .page-main {
   max-width: 1100px;
   margin: 0 auto;
-  padding: var(--space-6);
+  padding: var(--space-4) var(--space-5);
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-3);
 }
 
 .empty {
   text-align: center;
-  padding: var(--space-8) var(--space-4);
+  padding: var(--space-6) var(--space-4);
   background: var(--bg-soft);
   border-radius: var(--radius);
 }
@@ -186,17 +186,17 @@ button:focus-visible {
 .live {
   background: var(--bg-soft);
   border-radius: var(--radius);
-  padding: var(--space-5);
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 
 .live-head {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1);
 }
 
 .live-head h2 {
@@ -262,12 +262,12 @@ button:focus-visible {
 .live-grids {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 
 @media (min-width: 720px) {
   .live-grids {
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 }
 
@@ -282,7 +282,7 @@ button:focus-visible {
 .big-stat {
   flex: 1 1 8rem;
   background: var(--bg-inset);
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   display: flex;
   flex-direction: column;
@@ -297,9 +297,16 @@ button:focus-visible {
 }
 
 .big-stat .val {
-  font-size: 1.625rem;
+  font-size: 1.5rem;
   font-weight: 800;
   line-height: 1;
+}
+
+.big-stat .val .suffix {
+  font-size: 0.875rem;
+  color: var(--muted);
+  font-weight: 600;
+  margin-left: 0.125rem;
 }
 
 .big-stat.score .val { color: var(--accent); }
@@ -357,10 +364,10 @@ button:focus-visible {
 .hero {
   background: var(--bg-soft);
   border-radius: var(--radius);
-  padding: var(--space-5);
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 
 .hero-head {
@@ -452,22 +459,22 @@ button:focus-visible {
 .cats {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 
 @media (min-width: 720px) {
   .cats {
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 }
 
 .cat {
   background: var(--bg-soft);
   border-radius: var(--radius);
-  padding: var(--space-4) var(--space-5);
+  padding: var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 .cat h2 {
@@ -477,7 +484,7 @@ button:focus-visible {
   color: var(--accent);
   font-weight: 700;
   border-bottom: 1px solid var(--border);
-  padding-bottom: var(--space-2);
+  padding-bottom: var(--space-1);
 }
 
 .rows {
@@ -486,7 +493,7 @@ button:focus-visible {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 0;
 }
 
 .row {
@@ -494,9 +501,9 @@ button:focus-visible {
   grid-template-columns: 1fr auto auto auto;
   align-items: baseline;
   gap: var(--space-3);
-  padding: var(--space-2) 0;
+  padding: var(--space-1) 0;
   border-bottom: 1px dashed var(--border);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
 }
 
 .row:last-child {
@@ -509,7 +516,7 @@ button:focus-visible {
 
 .row .value {
   font-weight: 800;
-  font-size: 1.0625rem;
+  font-size: 1rem;
 }
 
 .row .compare,
@@ -532,10 +539,10 @@ button:focus-visible {
 .trend {
   background: var(--bg-soft);
   border-radius: var(--radius);
-  padding: var(--space-4) var(--space-5);
+  padding: var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 .trend h2 {
@@ -613,10 +620,10 @@ button:focus-visible {
 .today-detail {
   background: var(--bg-soft);
   border-radius: var(--radius);
-  padding: var(--space-5);
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 
 .today-head h2 {

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -80,9 +80,9 @@ button:focus-visible {
 /* ── Header ─────────────────────────────────────────────────────────── */
 
 .page-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
   align-items: center;
-  justify-content: space-between;
   gap: var(--space-4);
   padding: var(--space-3) var(--space-5);
   border-bottom: 1px solid var(--border);
@@ -90,6 +90,33 @@ button:focus-visible {
   position: sticky;
   top: 0;
   z-index: 1;
+}
+
+.header-scoreline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  font-weight: 700;
+}
+.header-scoreline .team {
+  font-size: 0.625rem;
+  letter-spacing: 0.18em;
+}
+.header-scoreline .blue { color: var(--blue); }
+.header-scoreline .orange { color: var(--orange); }
+.header-scoreline .num {
+  font-size: 1.375rem;
+  min-width: 1.25rem;
+  text-align: center;
+  font-weight: 800;
+  line-height: 1;
+}
+.header-scoreline .clock {
+  color: var(--fg);
+  font-size: 0.9375rem;
+  padding: 0 var(--space-1);
+  font-variant-numeric: tabular-nums;
 }
 
 .page-header h1 {
@@ -220,33 +247,6 @@ button:focus-visible {
 }
 .banner.replay { background: #c084fc; color: #1a1a1a; }
 .banner.overtime { background: var(--bad); color: #fff; }
-
-.scoreline {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-4);
-  font-size: 1.25rem;
-  font-weight: 700;
-}
-.scoreline .team {
-  font-size: 0.6875rem;
-  letter-spacing: 0.18em;
-}
-.scoreline .blue { color: var(--blue); }
-.scoreline .orange { color: var(--orange); }
-.scoreline .num {
-  font-size: 1.75rem;
-  min-width: 1.5rem;
-  text-align: center;
-  font-weight: 800;
-}
-.scoreline .clock {
-  color: var(--fg);
-  font-size: 1.125rem;
-  padding: 0 var(--space-2);
-  font-variant-numeric: tabular-nums;
-}
 
 .me-line {
   display: flex;

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -72,6 +72,8 @@
     $("me-team").style.color = me.team === 0 ? "#1873ff" : me.team === 1 ? "#ff8a1f" : "";
 
     $("m-score").textContent = m.score ?? 0;
+    $("m-boost").textContent = m.boost ?? 0;
+    $("m-speed").textContent = m.speed ?? 0;
     $("m-goals").textContent = m.goals ?? 0;
     $("m-shots").textContent = m.shots ?? 0;
     $("m-acc").textContent = `(${m.shot_accuracy ?? 0}%)`;
@@ -86,6 +88,11 @@
     $("m-goal-part").textContent = `${m.goal_participation_pct ?? 0}%`;
     $("m-hardest").textContent = m.hardest_hit ?? 0;
     $("m-avg-shot-pwr").textContent = m.avg_shot_power ?? 0;
+    $("m-boost-avg").textContent = m.boost_avg ?? 0;
+    $("m-boost-wasted").textContent = `${m.boost_wasted_pct ?? 0}%`;
+    $("m-zero-boost").textContent = `${m.time_zero_boost_pct ?? 0}%`;
+    $("m-supersonic").textContent = `${m.time_supersonic_pct ?? 0}%`;
+    $("m-airborne").textContent = `${m.time_airborne_pct ?? 0}%`;
 
     const rawTouch = m.last_touch;
     const touchKey = Object.prototype.hasOwnProperty.call(ALLOWED_TOUCH, rawTouch) ? rawTouch : "none";

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -11,6 +11,7 @@
   const trendSection = $("trend-section");
   const todayDetail = $("today-detail");
   const banner = $("banner");
+  const headerScoreline = $("header-scoreline");
 
   const setConn = (state, label) => {
     conn.dataset.state = state;
@@ -44,6 +45,7 @@
 
   const renderMatch = (snap) => {
     live.hidden = false;
+    headerScoreline.hidden = false;
     const ctx = snap.context || {};
     const m = snap.match || {};
     const me = snap.me || {};


### PR DESCRIPTION
## Summary

Two things the screenshot from prod surfaced:

1. **Missing live data.** The README promised BOOST and SPEED big indicators, plus live BOOST and MOVEMENT panels. The snapshot already ships those fields (\`boost\`, \`speed\`, \`boost_avg\`, \`boost_wasted_pct\`, \`time_zero_boost_pct\`, \`time_supersonic_pct\`, \`time_airborne_pct\`), but \`index.html\` only had SCORE / OUTPUT / BALL / COMBAT — the rest was rendered nowhere. Added the markup and the corresponding lines in \`renderMatch\`.

2. **Layout was too breathy.** Tightened paddings/gaps across cards, header, and the coach rows so the dashboard fits more on screen without aggressive zoom.

## Changes

- \`index.html\`: 2 new big-stats (BOOST current %, SPEED) next to SCORE; 2 new live grids (BOOST aggregate, MOVEMENT).
- \`overlay.js\`: render the 5 new fields in \`renderMatch\`.
- \`overlay.css\`: trimmed paddings/gaps in \`.live\`, \`.hero\`, \`.cat\`, \`.today-detail\`, \`.trend\`, \`.page-main\`, \`.page-header\`, \`.row\`, \`.big-stat\`. Added a muted \`%\` suffix style.

## Test plan

- [x] \`pytest tests/\` — 140 passed (no Python touched, but sanity check).
- [ ] On Windows: rebuild .exe, enter a match — verify boost/speed update in real time, BOOST/MOVEMENT sections fill in, dashboard fits more on a single screen.