### PR TITLE
feat(coach): split coach stats by mode (1v1 / 2v2 / 3v3)

### DIFF
--- a/app.py
+++ b/app.py
@@ -296,7 +296,7 @@ DEMO_COACH_SNAPSHOT = {
         "id": 12, "match_guid": "DEMO-FIXED", "player_name": "alas",
         "started_at": "2026-05-02T20:00:00+00:00",
         "ended_at": "2026-05-02T20:05:00+00:00",
-        "blue_score": 4, "orange_score": 2, "me_team": 0, "won": True,
+        "blue_score": 4, "orange_score": 2, "me_team": 0, "team_size": 2, "won": True,
         "score": 425, "goals": 2, "shots": 5, "saves": 3, "assists": 1,
         "demos": 1, "demos_taken": 2, "touches": 18,
         "boost_avg": 54.0, "time_zero_boost_pct": 4.0,
@@ -426,23 +426,23 @@ async def coach() -> RedirectResponse:
 
 
 @app.get("/api/today")
-async def api_today() -> dict:
+async def api_today(mode: Optional[int] = None) -> dict:
     if app.state.demo:
         return dict(DEMO_TODAY_SNAPSHOT)
     if not agg.me_id or db is None:
         return dict(EMPTY_TODAY)
     # Run SQLite I/O in a thread so a slow disk doesn't block the event loop.
-    return await asyncio.to_thread(today_stats, db, agg.me_id)
+    return await asyncio.to_thread(today_stats, db, agg.me_id, mode)
 
 
 @app.get("/api/coach")
-async def api_coach() -> dict:
+async def api_coach(mode: Optional[int] = None) -> dict:
     if app.state.demo:
         return dict(DEMO_COACH_SNAPSHOT)
     if not agg.me_id or db is None:
         return dict(EMPTY_COACH)
     target_rank = _resolve_target_rank()
-    return await asyncio.to_thread(coach_stats, db, agg.me_id, target_rank)
+    return await asyncio.to_thread(coach_stats, db, agg.me_id, target_rank, mode)
 
 
 @app.post("/api/config/rank")

--- a/state.py
+++ b/state.py
@@ -139,6 +139,7 @@ class MatchAggregator:
     in_replay: bool = False
     arena: str = ""
     clock: int = 0
+    team_size: int | None = None
 
     # Identity-detection state — track Target during the first frames after Initialized
     _detect_window_frames: int = field(default=0, repr=False)
@@ -180,6 +181,9 @@ class MatchAggregator:
         self.in_replay = bool(game.get("bReplay"))
         self.arena = game.get("Arena", self.arena)
         self.clock = int(game.get("TimeSeconds", self.clock))
+        team_size = game.get("TeamSize")
+        if isinstance(team_size, int) and team_size > 0:
+            self.team_size = team_size
 
         # Init match guid if first frame is UpdateState (no Initialized seen).
         # NOTE: caller is responsible for persisting the prior match snapshot
@@ -589,6 +593,7 @@ class MatchAggregator:
             "blue_score": self.blue_score,
             "orange_score": self.orange_score,
             "me_team": self.me_team,
+            "team_size": self.team_size,
             "won": self.won(),
             "score": self.score,
             "goals": self.goals,

--- a/static/index.html
+++ b/static/index.html
@@ -35,6 +35,12 @@
         </select>
       </label>
       <span class="conn" id="conn" aria-live="polite" data-state="connecting">connecting…</span>
+      <nav class="mode-tabs" id="mode-tabs" aria-label="Filter coach stats by match mode">
+        <button type="button" class="mode-tab" data-mode="" aria-pressed="true">All</button>
+        <button type="button" class="mode-tab" data-mode="1" aria-pressed="false">1v1</button>
+        <button type="button" class="mode-tab" data-mode="2" aria-pressed="false">2v2</button>
+        <button type="button" class="mode-tab" data-mode="3" aria-pressed="false">3v3</button>
+      </nav>
     </header>
 
     <main class="page-main">

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -185,6 +185,38 @@ button:focus-visible {
   border-color: var(--bad);
 }
 
+.mode-tabs {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  padding-top: var(--space-2);
+}
+
+.mode-tab {
+  background: var(--bg-soft);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.75rem;
+  font-family: inherit;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.mode-tab:hover {
+  background: var(--bg-soft-hover);
+  color: var(--fg);
+}
+
+.mode-tab[aria-pressed="true"] {
+  background: var(--accent);
+  color: #1a1a1a;
+  border-color: var(--accent);
+}
+
 /* ── Layout ─────────────────────────────────────────────────────────── */
 
 .page-main {

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -403,19 +403,66 @@
     renderTrend(data.trend);
   };
 
+  // ── Mode filter (1v1 / 2v2 / 3v3 / All) ──────────────────────────
+
+  const VALID_MODES = new Set(["1", "2", "3"]);
+  let currentMode = "";
+
+  const readModeFromUrl = () => {
+    const m = new URL(location.href).searchParams.get("mode");
+    return VALID_MODES.has(m) ? m : "";
+  };
+
+  const writeModeToUrl = (mode) => {
+    const url = new URL(location.href);
+    if (mode) url.searchParams.set("mode", mode);
+    else url.searchParams.delete("mode");
+    history.replaceState(null, "", url);
+  };
+
+  const syncModeButtons = () => {
+    for (const btn of document.querySelectorAll(".mode-tab")) {
+      btn.setAttribute("aria-pressed", btn.dataset.mode === currentMode ? "true" : "false");
+    }
+  };
+
+  const buildModeQuery = () => (currentMode ? `?mode=${currentMode}` : "");
+
   // ── Initial fetches (covers refresh with no live game) ───────────
 
-  const fetchInitial = async () => {
+  const fetchCoachAndToday = async () => {
     try {
+      const q = buildModeQuery();
       const [coachRes, todayRes] = await Promise.all([
-        fetch("/api/coach"),
-        fetch("/api/today"),
+        fetch(`/api/coach${q}`),
+        fetch(`/api/today${q}`),
       ]);
       if (coachRes.ok) renderCoach(await coachRes.json());
       if (todayRes.ok) renderToday(await todayRes.json());
     } catch {
       // Network failure on first load — the WS will refill once connected.
     }
+  };
+
+  const fetchInitial = fetchCoachAndToday;
+
+  const setMode = (mode) => {
+    const normalized = VALID_MODES.has(mode) ? mode : "";
+    if (normalized === currentMode) return;
+    currentMode = normalized;
+    writeModeToUrl(currentMode);
+    syncModeButtons();
+    fetchCoachAndToday();
+  };
+
+  const initModeTabs = () => {
+    currentMode = readModeFromUrl();
+    syncModeButtons();
+    document.getElementById("mode-tabs").addEventListener("click", (e) => {
+      const btn = e.target.closest(".mode-tab");
+      if (!btn) return;
+      setMode(btn.dataset.mode ?? "");
+    });
   };
 
   // ── WebSocket ────────────────────────────────────────────────────
@@ -440,8 +487,14 @@
       if (msg.type === "match" && msg.data) {
         renderMatch(msg.data);
         markMatchActive();
-      } else if (msg.type === "today" && msg.data) renderToday(msg.data);
-      else if (msg.type === "coach" && msg.data) renderCoach(msg.data);
+      } else if (msg.type === "today" && msg.data) {
+        // When a mode filter is active, the coach broadcast triggers a fresh
+        // filtered fetch that also refreshes today — skip the unfiltered push.
+        if (!currentMode) renderToday(msg.data);
+      } else if (msg.type === "coach" && msg.data) {
+        if (currentMode) fetchCoachAndToday();
+        else renderCoach(msg.data);
+      }
     };
     socket.onclose = () => {
       clearMatchActive();
@@ -483,6 +536,7 @@
     select.dataset.committed = select.value;
   };
 
+  initModeTabs();
   fetchInitial();
   connect();
   initRankSelect();

--- a/storage.py
+++ b/storage.py
@@ -173,6 +173,7 @@ CREATE TABLE IF NOT EXISTS matches (
     pool_shots INTEGER DEFAULT 0,
     saviors INTEGER DEFAULT 0,
     mvps INTEGER DEFAULT 0,
+    team_size INTEGER,
     UNIQUE(match_guid, player_id)
 );
 """
@@ -202,6 +203,7 @@ _NEW_COLUMNS: list[tuple[str, str]] = [
     ("pool_shots", "INTEGER DEFAULT 0"),
     ("saviors", "INTEGER DEFAULT 0"),
     ("mvps", "INTEGER DEFAULT 0"),
+    ("team_size", "INTEGER"),
 ]
 
 
@@ -247,11 +249,11 @@ def save_match(conn: sqlite3.Connection, snapshot: dict) -> bool:
             last_back_pct, dist_to_ball_avg, big_pads, small_pads, boost_stolen,
             aerial_touches, fast_aerials,
             epic_saves, hat_tricks, aerial_goals, bicycle_goals, long_goals,
-            centers, pool_shots, saviors, mvps
+            centers, pool_shots, saviors, mvps, team_size
         ) VALUES (
             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-            ?, ?, ?, ?, ?, ?, ?, ?, ?
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
         """,
         (
@@ -301,13 +303,16 @@ def save_match(conn: sqlite3.Connection, snapshot: dict) -> bool:
             snapshot.get("pool_shots", 0),
             snapshot.get("saviors", 0),
             snapshot.get("mvps", 0),
+            snapshot.get("team_size"),
         ),
     )
     conn.commit()
     return cur.rowcount > 0
 
 
-def today_stats(conn: sqlite3.Connection, player_id: str) -> dict:
+def today_stats(
+    conn: sqlite3.Connection, player_id: str, mode: int | None = None
+) -> dict:
     cur = conn.execute(
         """
         SELECT
@@ -330,8 +335,9 @@ def today_stats(conn: sqlite3.Connection, player_id: str) -> dict:
         FROM matches
         WHERE player_id = ?
         AND date(started_at, 'localtime') = date('now', 'localtime')
+        AND (? IS NULL OR team_size = ?)
         """,
-        (player_id,),
+        (player_id, mode, mode),
     )
     row = cur.fetchone()
     columns = [c[0] for c in cur.description]
@@ -358,11 +364,13 @@ def today_stats(conn: sqlite3.Connection, player_id: str) -> dict:
         "avg_supersonic_pct": round(raw["avg_supersonic"]),
         "total_ball_hits": raw["total_ball_hits"],
         "best_hit": round(raw["best_hit"], 1),
-        "win_streak": _current_win_streak(conn, player_id),
+        "win_streak": _current_win_streak(conn, player_id, mode),
     }
 
 
-def _current_win_streak(conn: sqlite3.Connection, player_id: str) -> int:
+def _current_win_streak(
+    conn: sqlite3.Connection, player_id: str, mode: int | None = None
+) -> int:
     """Consecutive wins from the most recent match, today only.
     Both losses and draws (won = NULL) break the streak."""
     cur = conn.execute(
@@ -370,9 +378,10 @@ def _current_win_streak(conn: sqlite3.Connection, player_id: str) -> int:
         SELECT won FROM matches
         WHERE player_id = ?
           AND date(started_at, 'localtime') = date('now', 'localtime')
+          AND (? IS NULL OR team_size = ?)
         ORDER BY ended_at DESC
         """,
-        (player_id,),
+        (player_id, mode, mode),
     )
     streak = 0
     for (won,) in cur.fetchall():
@@ -429,10 +438,18 @@ def _duration_minutes(started_at: str | None, ended_at: str | None) -> int:
     return max(0, round(delta))
 
 
-def _last_match(conn: sqlite3.Connection, player_id: str) -> dict | None:
+def _last_match(
+    conn: sqlite3.Connection, player_id: str, mode: int | None = None
+) -> dict | None:
     cur = conn.execute(
-        "SELECT * FROM matches WHERE player_id = ? ORDER BY ended_at DESC LIMIT 1",
-        (player_id,),
+        """
+        SELECT * FROM matches
+        WHERE player_id = ?
+          AND (? IS NULL OR team_size = ?)
+        ORDER BY ended_at DESC
+        LIMIT 1
+        """,
+        (player_id, mode, mode),
     )
     row = cur.fetchone()
     if row is None:
@@ -445,6 +462,7 @@ def _rolling_avg(
     conn: sqlite3.Connection,
     player_id: str,
     exclude_id: int | None,
+    mode: int | None = None,
     window: int = COACH_ROLLING_WINDOW,
 ) -> dict:
     cur = conn.execute(
@@ -487,11 +505,12 @@ def _rolling_avg(
             SELECT * FROM matches
             WHERE player_id = ?
               AND (? IS NULL OR id != ?)
+              AND (? IS NULL OR team_size = ?)
             ORDER BY ended_at DESC
             LIMIT ?
         )
         """,
-        (player_id, exclude_id, exclude_id, window),
+        (player_id, exclude_id, exclude_id, mode, mode, window),
     )
     row = cur.fetchone()
     columns = [c[0] for c in cur.description]
@@ -508,7 +527,10 @@ def _rolling_avg(
 
 
 def _trend_by_day(
-    conn: sqlite3.Connection, player_id: str, days: int = COACH_TREND_DAYS
+    conn: sqlite3.Connection,
+    player_id: str,
+    mode: int | None = None,
+    days: int = COACH_TREND_DAYS,
 ) -> list[dict]:
     cur = conn.execute(
         """
@@ -524,10 +546,11 @@ def _trend_by_day(
         FROM matches
         WHERE player_id = ?
           AND date(started_at, 'localtime') >= date('now', 'localtime', ?)
+          AND (? IS NULL OR team_size = ?)
         GROUP BY day
         ORDER BY day ASC
         """,
-        (player_id, f"-{days - 1} days"),
+        (player_id, f"-{days - 1} days", mode, mode),
     )
     out: list[dict] = []
     for row in cur.fetchall():
@@ -590,12 +613,15 @@ def _build_rank_benchmark(target_rank: str | None) -> dict | None:
 
 
 def coach_stats(
-    conn: sqlite3.Connection, player_id: str, target_rank: Optional[str] = None
+    conn: sqlite3.Connection,
+    player_id: str,
+    target_rank: str | None = None,
+    mode: int | None = None,
 ) -> dict:
-    last = _last_match(conn, player_id)
+    last = _last_match(conn, player_id, mode)
     exclude_id = last["id"] if last else None
-    avg = _rolling_avg(conn, player_id, exclude_id)
-    trend = _trend_by_day(conn, player_id)
+    avg = _rolling_avg(conn, player_id, exclude_id, mode)
+    trend = _trend_by_day(conn, player_id, mode)
     rolling_count = avg.get("count") or 0
     insights = (
         _generate_insights(last, avg)
@@ -607,7 +633,7 @@ def coach_stats(
         "rolling_avg": avg,
         "trend": trend,
         "insights": insights,
-        "today": today_stats(conn, player_id),
+        "today": today_stats(conn, player_id, mode),
         "rank_benchmark": _build_rank_benchmark(target_rank),
     }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -614,6 +614,26 @@ def test_api_coach_includes_rank_benchmark_when_configured(fresh_state, tmp_path
     assert "rank_benchmark" in result
 
 
+def test_api_coach_filters_by_mode_query_param(fresh_state):
+    """Matches with different team_size are partitioned by ?mode=N."""
+    from datetime import datetime
+
+    today_iso = datetime.now().astimezone().isoformat()
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    for guid, ts in (("ONES", 1), ("TWOS", 2), ("THREES", 3)):
+        app.db.execute(
+            "INSERT INTO matches (match_guid, player_id, started_at, ended_at, won, "
+            "score, goals, shots, team_size) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (guid, "Steam|1|0", today_iso, today_iso, 1, 300, 1, 2, ts),
+        )
+    app.db.commit()
+
+    assert asyncio.run(app.api_coach(mode=2))["last_match"]["match_guid"] == "TWOS"
+    assert asyncio.run(app.api_coach(mode=3))["last_match"]["match_guid"] == "THREES"
+    assert asyncio.run(app.api_today())["matches"] == 3
+    assert asyncio.run(app.api_today(mode=2))["matches"] == 1
+
+
 # ── /coach legacy redirect ───────────────────────────────────────────────────
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -831,3 +831,57 @@ def test_statfeed_counters_reset_on_new_match():
 
     agg.on_initialized({"MatchGuid": "M2"})
     assert agg.epic_saves == 0
+
+
+# ── team_size ────────────────────────────────────────────────────────────────
+
+
+def test_team_size_captured_from_update_state():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    state = make_state()
+    state["Game"]["TeamSize"] = 2
+    agg.on_update_state(state)
+
+    assert agg.team_size == 2
+    assert agg.to_db_snapshot()["team_size"] == 2
+
+
+def test_team_size_remains_none_when_field_missing():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    agg.on_update_state(make_state())  # no TeamSize
+
+    assert agg.team_size is None
+    assert agg.to_db_snapshot()["team_size"] is None
+
+
+def test_team_size_ignores_non_int_payload():
+    """Bad payload from the API must not corrupt team_size."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    state = make_state()
+    state["Game"]["TeamSize"] = "two"
+    agg.on_update_state(state)
+
+    assert agg.team_size is None
+
+
+def test_team_size_resets_with_new_match():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    state = make_state()
+    state["Game"]["TeamSize"] = 3
+    agg.on_update_state(state)
+    assert agg.team_size == 3
+
+    agg.on_initialized({"MatchGuid": "M2"})
+    assert agg.team_size is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -590,3 +590,166 @@ def test_coach_stats_with_invalid_target_rank_returns_null(tmp_path: Path, monke
     db = open_db(tmp_path / "stats.db")
     result = coach_stats(db, "Steam|1|0", target_rank="nonexistent")
     assert result["rank_benchmark"] is None
+
+
+# ── team_size persistence + mode filtering ──────────────────────────────────
+
+
+def test_save_match_persists_team_size(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    save_match(db, make_snapshot(match_guid="2V2", team_size=2))
+    row = db.execute("SELECT team_size FROM matches WHERE match_guid='2V2'").fetchone()
+    assert row == (2,)
+
+
+def test_save_match_team_size_defaults_to_null(tmp_path):
+    """Snapshots from older code paths without team_size must store NULL, not 0."""
+    db = open_db(tmp_path / "stats.db")
+    save_match(db, make_snapshot())  # no team_size key
+    row = db.execute("SELECT team_size FROM matches WHERE match_guid='M1'").fetchone()
+    assert row == (None,)
+
+
+def test_today_stats_filters_by_mode(tmp_path):
+    from datetime import datetime
+
+    db = open_db(tmp_path / "stats.db")
+    today_iso = datetime.now().astimezone().isoformat()
+    save_match(db, make_snapshot(match_guid="A", started_at=today_iso, ended_at=today_iso,
+                                 won=True, team_size=2))
+    save_match(db, make_snapshot(match_guid="B", started_at=today_iso, ended_at=today_iso,
+                                 won=False, team_size=3))
+    save_match(db, make_snapshot(match_guid="C", started_at=today_iso, ended_at=today_iso,
+                                 won=True, team_size=None))  # legacy row
+
+    # All — includes every match regardless of team_size
+    assert today_stats(db, "Steam|1|0")["matches"] == 3
+    # Filtered modes exclude legacy NULL rows
+    assert today_stats(db, "Steam|1|0", mode=2)["matches"] == 1
+    assert today_stats(db, "Steam|1|0", mode=3)["matches"] == 1
+    assert today_stats(db, "Steam|1|0", mode=1)["matches"] == 0
+
+
+def test_coach_stats_filters_last_match_by_mode(tmp_path):
+    from datetime import datetime, timedelta
+
+    db = open_db(tmp_path / "stats.db")
+    base = datetime.now().astimezone()
+    # Most recent overall is 1v1
+    save_match(db, make_snapshot(
+        match_guid="ONES",
+        started_at=(base - timedelta(hours=1)).isoformat(),
+        ended_at=base.isoformat(),
+        team_size=1, score=900,
+    ))
+    save_match(db, make_snapshot(
+        match_guid="TWOS",
+        started_at=(base - timedelta(hours=2)).isoformat(),
+        ended_at=(base - timedelta(minutes=30)).isoformat(),
+        team_size=2, score=500,
+    ))
+
+    assert coach_stats(db, "Steam|1|0")["last_match"]["match_guid"] == "ONES"
+    assert coach_stats(db, "Steam|1|0", mode=1)["last_match"]["match_guid"] == "ONES"
+    assert coach_stats(db, "Steam|1|0", mode=2)["last_match"]["match_guid"] == "TWOS"
+    assert coach_stats(db, "Steam|1|0", mode=3)["last_match"] is None
+
+
+def test_coach_stats_mode_excludes_legacy_null_rows(tmp_path):
+    """Matches saved before team_size tracking (NULL) must not appear under
+    a specific mode tab — only in 'All'."""
+    db = open_db(tmp_path / "stats.db")
+    save_match(db, make_snapshot(match_guid="OLD", team_size=None))
+    save_match(db, make_snapshot(
+        match_guid="NEW", team_size=2,
+        started_at="2026-05-01T20:00:00+00:00",
+        ended_at="2026-05-01T20:05:00+00:00",
+    ))
+
+    assert coach_stats(db, "Steam|1|0", mode=2)["last_match"]["match_guid"] == "NEW"
+    # In "All", the most recent (NEW) is the last_match and rolling avg sees OLD
+    assert coach_stats(db, "Steam|1|0")["last_match"]["match_guid"] == "NEW"
+    assert coach_stats(db, "Steam|1|0")["rolling_avg"]["count"] == 1
+
+
+def test_coach_stats_rolling_avg_filters_by_mode(tmp_path):
+    from datetime import datetime, timedelta
+
+    db = open_db(tmp_path / "stats.db")
+    base = datetime.now().astimezone()
+    # Latest match is 2v2 with score 300 — excluded from rolling avg
+    save_match(db, make_snapshot(
+        match_guid="LATEST",
+        started_at=(base - timedelta(minutes=5)).isoformat(),
+        ended_at=base.isoformat(),
+        team_size=2, score=300,
+    ))
+    # Two 2v2 history matches with score 600 each
+    for i in range(2):
+        save_match(db, make_snapshot(
+            match_guid=f"P2V2_{i}",
+            started_at=(base - timedelta(hours=i + 2)).isoformat(),
+            ended_at=(base - timedelta(hours=i + 1)).isoformat(),
+            team_size=2, score=600,
+        ))
+    # One 3v3 history match with score 100 — must not pollute the 2v2 avg
+    save_match(db, make_snapshot(
+        match_guid="THREES",
+        started_at=(base - timedelta(hours=5)).isoformat(),
+        ended_at=(base - timedelta(hours=4)).isoformat(),
+        team_size=3, score=100,
+    ))
+
+    res = coach_stats(db, "Steam|1|0", mode=2)
+    assert res["rolling_avg"]["score"] == 600  # only the two P2V2 history rows
+
+
+def test_coach_stats_trend_filters_by_mode(tmp_path):
+    from datetime import datetime, timedelta
+
+    db = open_db(tmp_path / "stats.db")
+    today = datetime.now().astimezone()
+    yesterday = today - timedelta(days=1)
+
+    save_match(db, make_snapshot(match_guid="T2V2", started_at=today.isoformat(),
+                                 ended_at=today.isoformat(), won=True, team_size=2))
+    save_match(db, make_snapshot(match_guid="Y3V3", started_at=yesterday.isoformat(),
+                                 ended_at=yesterday.isoformat(), won=False, team_size=3))
+
+    res_2 = coach_stats(db, "Steam|1|0", mode=2)
+    days = [d["day"] for d in res_2["trend"]]
+    assert today.strftime("%Y-%m-%d") in days
+    assert yesterday.strftime("%Y-%m-%d") not in days
+
+
+def test_migration_adds_team_size_column_to_existing_db(tmp_path):
+    """A DB created before team_size existed must get the column on open."""
+    import sqlite3
+
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE matches (
+            id INTEGER PRIMARY KEY,
+            match_guid TEXT NOT NULL,
+            player_id TEXT NOT NULL,
+            player_name TEXT,
+            started_at TEXT NOT NULL,
+            ended_at TEXT NOT NULL,
+            UNIQUE(match_guid, player_id)
+        )
+    """)
+    conn.execute(
+        "INSERT INTO matches (match_guid, player_id, started_at, ended_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("OLD", "Steam|1|0", "2026-01-01T00:00:00+00:00", "2026-01-01T00:05:00+00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    migrated = open_db(db_path)
+    columns = {row[1] for row in migrated.execute("PRAGMA table_info(matches)")}
+    assert "team_size" in columns
+
+    row = migrated.execute("SELECT team_size FROM matches WHERE match_guid='OLD'").fetchone()
+    assert row == (None,)


### PR DESCRIPTION
Closes #4.

## Summary
- Persist `Game.TeamSize` on each saved match (`MatchAggregator.team_size` → DB column via additive migration).
- Filter `/api/coach` and `/api/today` by optional `?mode=N` query param. Filter is applied to `last_match`, `rolling_avg`, `trend_by_day`, `today_stats`, and `win_streak` so every section of the coach view stays coherent under the same filter.
- Segmented control in the header (All / 1v1 / 2v2 / 3v3) with `aria-pressed` state, persisted as `?mode=N` in the URL (bookmarkeable). WS coach/today payloads are ignored when a filter is active; the UI re-fetches via HTTP instead.
- Legacy rows with `team_size = NULL` only appear in **All**, never in filtered tabs. No backfill, no fallback detection (if `Game.TeamSize` is missing, `team_size = NULL`).

## Implementation notes
- `app.py` uses `Optional[int]` (not `int | None`) for the query param: FastAPI evaluates the annotation via `get_type_hints()`, which breaks in Python 3.9 (the venv version in this repo). `state.py`/`storage.py` keep `int | None` because their annotations are never evaluated at runtime.
- Self-reflection: `#1a1a1a` is hardcoded three times in `overlay.css` (two pre-existing, one new). Flagged as #15 with `legacy-violation` label for a future refactor pass — not fixed here per `implementation-principles.md` (match existing file style, no colateral cleanup in a feature PR).

## Test plan
- [x] `pytest -q` (153 passing — 13 new tests across `tests/test_state.py`, `tests/test_storage.py`, `tests/test_app.py`)
- [ ] Manual: run `.venv/bin/python app.py --demo`, open `http://127.0.0.1:8080/`, verify tab toggle updates URL and `aria-pressed` state; reload with `?mode=2` preselects 2v2.
- [ ] Real-game smoke test: confirm `Game.TeamSize` is actually populated in the live Stats API stream (the issue states this field exists; verification with a live match would close the loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)