### PR TITLE
fix(api): harden against RL Stats API field variations

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,11 @@ BUNDLED_INI = _resource_path("DefaultStatsAPI.ini")
 # already show in the in-game HUD, so we don't need frame-rate updates here.
 # Discrete events (BallHit, goals, shots) still broadcast immediately.
 UPDATE_STATE_MIN_INTERVAL = 5.0
-MATCH_END_EVENTS = {"MatchEnded", "PodiumStart"}
+# MatchDestroyed fires when the user closes RL or leaves a match mid-game —
+# without it we'd lose those rows. The match is then incomplete (score / time
+# elapsed reflect when the user bailed), so downstream consumers should treat
+# it like any other persisted match.
+MATCH_END_EVENTS = {"MatchEnded", "PodiumStart", "MatchDestroyed"}
 
 
 class Hub:

--- a/state.py
+++ b/state.py
@@ -35,6 +35,19 @@ LAST_TOUCH_SELF = "self"
 LAST_TOUCH_TEAM = "team"
 LAST_TOUCH_OPPONENT = "opp"
 
+# Keys Psyonix has used over time to expose the currently spectated player on
+# the Game object. Probed in priority order; the first one whose nested dict
+# has a Name wins. `bHasTarget` is intentionally not gating — some builds
+# populate the player payload without setting that flag.
+_TARGET_KEYS: tuple[str, ...] = (
+    "Target",
+    "TargetPlayer",
+    "FocusedPlayer",
+    "Player",
+    "SpectatedPlayer",
+    "PrimaryPlayer",
+)
+
 # Allowlist of StatfeedEvent names → MatchAggregator attribute.
 # Keys are lowercase for case-insensitive lookup.
 _STATFEED_EVENTS: dict[str, str] = {
@@ -58,6 +71,18 @@ def _norm_y(y: float, team: int) -> float:
     Blue (team=0) defends the -Y side, Orange (team=1) defends the +Y side.
     """
     return float(y) if team == 0 else -float(y)
+
+
+def _target_name(game: dict) -> str | None:
+    """Return the spectated/focused player Name, probing the keys Psyonix has
+    used across RL builds. Returns None when no candidate exposes a Name."""
+    for key in _TARGET_KEYS:
+        candidate = game.get(key)
+        if isinstance(candidate, dict):
+            name = candidate.get("Name")
+            if name:
+                return name
+    return None
 
 
 @dataclass
@@ -140,6 +165,8 @@ class MatchAggregator:
     arena: str = ""
     clock: int = 0
     team_size: int | None = None
+    ball_speed: float = 0.0
+    ball_team: int | None = None
 
     # Identity-detection state — track Target during the first frames after Initialized
     _detect_window_frames: int = field(default=0, repr=False)
@@ -184,6 +211,14 @@ class MatchAggregator:
         team_size = game.get("TeamSize")
         if isinstance(team_size, int) and team_size > 0:
             self.team_size = team_size
+
+        ball = game.get("Ball")
+        if isinstance(ball, dict):
+            speed = ball.get("Speed")
+            if isinstance(speed, (int, float)):
+                self.ball_speed = float(speed)
+            team_num = ball.get("TeamNum")
+            self.ball_team = team_num if team_num in (0, 1) else None
 
         # Init match guid if first frame is UpdateState (no Initialized seen).
         # NOTE: caller is responsible for persisting the prior match snapshot
@@ -430,10 +465,7 @@ class MatchAggregator:
         if self.me_id or self._detect_window_frames <= 0:
             return None
         self._detect_window_frames -= 1
-        if not game.get("bHasTarget"):
-            return None
-        target = game.get("Target") or {}
-        target_name = target.get("Name")
+        target_name = _target_name(game)
         if not target_name:
             return None
         self._detect_target_counts[target_name] = (
@@ -554,6 +586,8 @@ class MatchAggregator:
                 "overtime": self.in_overtime,
                 "replay": self.in_replay,
                 "arena": self.arena,
+                "ball_speed": round(self.ball_speed, 1),
+                "ball_team": self.ball_team,
             },
             "match": {
                 "score": self.score,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -175,6 +175,32 @@ def test_match_guid_change_persists_prior_match(fresh_state):
     assert ("MATCH_A", 100) in rows
 
 
+def test_match_destroyed_persists_match(fresh_state):
+    """If RL emits MatchDestroyed instead of MatchEnded (user quits mid-match
+    or the session is torn down), the in-progress match must still be saved."""
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M_DESTROY"}})
+    app.handle_event({
+        "Event": "UpdateState",
+        "Data": {
+            "MatchGuid": "M_DESTROY",
+            "Players": [{"Name": "alas", "PrimaryId": "Steam|1|0", "TeamNum": 0,
+                         "Score": 150, "Goals": 1, "Shots": 1, "Saves": 0,
+                         "Assists": 0, "Demos": 0, "Touches": 3, "Boost": 50,
+                         "Speed": 0, "bOnGround": True, "bHasCar": True}],
+            "Game": {"Teams": [{"TeamNum": 0, "Score": 1}, {"TeamNum": 1, "Score": 0}],
+                     "TimeSeconds": 200, "bOvertime": False, "bReplay": False,
+                     "Arena": "stadium", "bHasTarget": False},
+        },
+    })
+    app.handle_event({"Event": "MatchDestroyed", "Data": {"MatchGuid": "M_DESTROY"}})
+
+    row = app.db.execute(
+        "SELECT score FROM matches WHERE match_guid='M_DESTROY'"
+    ).fetchone()
+    assert row == (150,)
+
+
 def test_match_ended_persists_match(fresh_state):
     app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
     app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M1"}})

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -885,3 +885,66 @@ def test_team_size_resets_with_new_match():
 
     agg.on_initialized({"MatchGuid": "M2"})
     assert agg.team_size is None
+
+
+# ── Identity detection cascade ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "key", ["TargetPlayer", "FocusedPlayer", "Player", "SpectatedPlayer", "PrimaryPlayer"]
+)
+def test_identity_detected_via_alternate_target_key(key):
+    """Psyonix has shipped the spectated-player payload under several keys
+    over RL's history. Detection must still lock on when only the alternate
+    key is populated."""
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+    for _ in range(30):
+        s = make_state(target="alas")
+        s["Game"].pop("Target", None)
+        s["Game"][key] = {"Name": "alas", "Shortcut": 1, "TeamNum": 0}
+        agg.on_update_state(s)
+    assert agg.me_id == "Steam|1|0"
+
+
+def test_identity_detection_ignores_bhas_target_flag():
+    """Some builds populate Target.Name without setting bHasTarget=True."""
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+    for _ in range(30):
+        s = make_state(target="alas")
+        s["Game"]["bHasTarget"] = False
+        agg.on_update_state(s)
+    assert agg.me_id == "Steam|1|0"
+
+
+# ── Ball state in UpdateState ────────────────────────────────────────────────
+
+
+def test_ball_speed_and_team_captured_from_update_state():
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    s = make_state()
+    s["Game"]["Ball"] = {"Speed": 28.4, "TeamNum": 1}
+    agg.on_update_state(s)
+
+    out = agg.to_overlay_dict()
+    assert out["context"]["ball_speed"] == 28.4
+    assert out["context"]["ball_team"] == 1
+
+
+def test_ball_team_rejects_invalid_payload():
+    """Speed must be numeric; TeamNum must be 0 or 1."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    s = make_state()
+    s["Game"]["Ball"] = {"Speed": "fast", "TeamNum": 5}
+    agg.on_update_state(s)
+
+    out = agg.to_overlay_dict()
+    assert out["context"]["ball_speed"] == 0.0
+    assert out["context"]["ball_team"] is None


### PR DESCRIPTION
Three robustness fixes after cross-checking our field names against [jarrettabello/rocket-league-broadcast-studio](https://github.com/jarrettabello/rocket-league-broadcast-studio).

## Changes

### Identity detection — cascade of target keys
Old code locked identity only on `Game.Target.Name` and gated on `bHasTarget`. RLBS probes six keys (`Target`, `TargetPlayer`, `FocusedPlayer`, `Player`, `SpectatedPlayer`, `PrimaryPlayer`) because Psyonix has used different ones across RL builds. We now do the same and ignore `bHasTarget` — some builds populate the player payload without setting it. **Latent-bug risk eliminated**; existing tests still pass.

### MatchDestroyed end-of-match handler
If RL closes mid-match (e.g., user quits, session torn down), it can emit `MatchDestroyed` instead of `MatchEnded`. We were dropping those matches. Added to `MATCH_END_EVENTS`. The resulting row is incomplete (score reflects the moment the user bailed), but at least it's persisted.

### Ball.Speed + Ball.TeamNum exposed in overlay
RLBS reads `Game.Ball.Speed` and `Game.Ball.TeamNum` from every `UpdateState`. We were only capturing `PostHitSpeed` on `BallHit` (different metric — peak power, not current speed). Now exposes `context.ball_speed` and `context.ball_team` for live UI consumers (no DB change, runtime-only).

## Test plan
- [x] `pytest -q` (162 passing — 9 new tests: 5 parametrized over alternate target keys, 1 for bHasTarget ignore, 2 for ball state capture/validation, 1 for MatchDestroyed persistence)
- [ ] Live verification next time the game is running: confirm `Ball.Speed` actually arrives in `UpdateState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)