### PR TITLE
refactor(css): extract --fg-inverse token for dark-on-light surfaces

### DIFF
--- a/static/overlay.css
+++ b/static/overlay.css
@@ -6,6 +6,7 @@
   --bg-soft-hover: #1d2230;
   --bg-inset: #0f121b;
   --fg: #f5f5f5;
+  --fg-inverse: #1a1a1a;
   --muted: #9ea0aa;
   --border: rgba(255, 255, 255, 0.08);
   --accent: #ffd23f;
@@ -213,7 +214,7 @@ button:focus-visible {
 
 .mode-tab[aria-pressed="true"] {
   background: var(--accent);
-  color: #1a1a1a;
+  color: var(--fg-inverse);
   border-color: var(--accent);
 }
 
@@ -270,14 +271,14 @@ button:focus-visible {
 .banner {
   align-self: center;
   background: var(--accent);
-  color: #1a1a1a;
+  color: var(--fg-inverse);
   font-size: 0.6875rem;
   letter-spacing: 0.18em;
   padding: var(--space-1) var(--space-3);
   border-radius: var(--radius-sm);
   font-weight: 800;
 }
-.banner.replay { background: #c084fc; color: #1a1a1a; }
+.banner.replay { background: #c084fc; color: var(--fg-inverse); }
 .banner.overtime { background: var(--bad); color: #fff; }
 
 .me-line {


### PR DESCRIPTION
Closes #15.

## Summary
The hex literal `#1a1a1a` was repeated in three CSS rules (`.banner`, `.banner.replay`, `.mode-tab[aria-pressed="true"]`). Extracted to a `--fg-inverse` token in `:root` and replaced all three call sites. Named `--fg-inverse` (not `--fg-on-accent`) because `.banner.replay` uses the same color on a purple background, not on `--accent` — the token captures the semantic role (dark foreground, inverse of `--fg`) rather than the surface it lands on.

No behavior change.

## Test plan
- [x] No CSS regression — visual diff is identical (literal → token resolves to the same value).
- [x] Existing test suite (162) still passes (no CSS-touching tests, but ran for sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)