### PR TITLE
feat(roster): track all 6 lobby players, live + persisted

### DIFF
--- a/app.py
+++ b/app.py
@@ -199,12 +199,19 @@ def _broadcast_coach() -> None:
 
 
 def _persist_current_match() -> bool:
-    """Persist the current match if we have enough info. Returns True on insert."""
+    """Persist a row for every player observed in the match.
+
+    Returns True if at least one row was newly inserted.
+    """
     if db is None:
         return False
-    snap = agg.to_db_snapshot()
-    if save_match(db, snap):
-        log.info("saved match %s (won=%s)", snap["match_guid"], snap["won"])
+    snapshots = agg.to_db_snapshots()
+    inserted = 0
+    for snap in snapshots:
+        if save_match(db, snap):
+            inserted += 1
+    if inserted > 0:
+        log.info("saved match %s (%d player rows)", agg.match_guid, inserted)
         return True
     return False
 
@@ -269,6 +276,14 @@ async def tcp_pump(host: str, port: int) -> None:
 
 DEMO_MATCH_SNAPSHOT = {
     "me": {"id": "Steam|76561197960409023|0", "name": "alas", "team": 0},
+    "players": [
+        {"id": "Steam|76561197960409023|0", "name": "alas", "team": 0, "boost": 62, "is_me": True},
+        {"id": "Steam|2|0", "name": "tide", "team": 0, "boost": 38, "is_me": False},
+        {"id": "Steam|3|0", "name": "kio", "team": 0, "boost": 81, "is_me": False},
+        {"id": "Epic|4|0", "name": "jstn", "team": 1, "boost": 22, "is_me": False},
+        {"id": "Epic|5|0", "name": "zen", "team": 1, "boost": 54, "is_me": False},
+        {"id": "Epic|6|0", "name": "flux", "team": 1, "boost": 11, "is_me": False},
+    ],
     "context": {
         "blue": 2, "orange": 1, "clock": 187,
         "overtime": False, "replay": False, "arena": "cs_p",

--- a/state.py
+++ b/state.py
@@ -172,6 +172,11 @@ class MatchAggregator:
     _detect_window_frames: int = field(default=0, repr=False)
     _detect_target_counts: dict[str, int] = field(default_factory=dict, repr=False)
 
+    # Lobby roster — slim copy of the most recent Players[] for the overlay,
+    # and a per-PrimaryId latest snapshot for end-of-match persistence.
+    _latest_players: list[dict] = field(default_factory=list, repr=False)
+    players_seen: dict[str, dict] = field(default_factory=dict, repr=False)
+
     def reset_match(self, match_guid: str) -> None:
         keep = (self.me_id, self.me_name)
         self.__init__()  # type: ignore[misc]
@@ -219,6 +224,12 @@ class MatchAggregator:
                 self.ball_speed = float(speed)
             team_num = ball.get("TeamNum")
             self.ball_team = team_num if team_num in (0, 1) else None
+
+        self._latest_players = players
+        for p in players:
+            pid = p.get("PrimaryId")
+            if pid:
+                self.players_seen[pid] = p
 
         # Init match guid if first frame is UpdateState (no Initialized seen).
         # NOTE: caller is responsible for persisting the prior match snapshot
@@ -568,10 +579,13 @@ class MatchAggregator:
         return self.frames_pos > 0
 
     def won(self) -> bool | None:
-        if self.me_team < 0:
+        return self._won_for_team(self.me_team)
+
+    def _won_for_team(self, team: int) -> bool | None:
+        if team not in (0, 1):
             return None
-        my_score = self.blue_score if self.me_team == 0 else self.orange_score
-        opp_score = self.orange_score if self.me_team == 0 else self.blue_score
+        my_score = self.blue_score if team == 0 else self.orange_score
+        opp_score = self.orange_score if team == 0 else self.blue_score
         if my_score == opp_score:
             return None
         return my_score > opp_score
@@ -579,6 +593,17 @@ class MatchAggregator:
     def to_overlay_dict(self) -> dict:
         return {
             "me": {"id": self.me_id, "name": self.me_name, "team": self.me_team},
+            "players": [
+                {
+                    "id": p.get("PrimaryId"),
+                    "name": p.get("Name"),
+                    "team": p.get("TeamNum"),
+                    "boost": p.get("Boost", 0),
+                    "is_me": p.get("PrimaryId") == self.me_id,
+                }
+                for p in self._latest_players
+                if p.get("PrimaryId") and p.get("Name")
+            ],
             "context": {
                 "blue": self.blue_score,
                 "orange": self.orange_score,
@@ -615,6 +640,46 @@ class MatchAggregator:
                 "possession_pct": self.possession_pct(),
                 "boost_wasted_pct": self.boost_wasted_pct(),
             },
+        }
+
+    def to_db_snapshots(self) -> list[dict]:
+        """Return one row per player observed during the match.
+
+        The user ("me") row carries all derived metrics (boost_avg, positioning,
+        mechanics) since those require frame-level state we only track for the
+        identified user. The other rows carry only end-of-match player stats
+        from the latest Players[] payload — derived fields are 0/None.
+        """
+        snapshots: list[dict] = []
+        me_snap = self.to_db_snapshot()
+        if me_snap.get("player_id"):
+            snapshots.append(me_snap)
+        for pid, payload in self.players_seen.items():
+            if pid == self.me_id:
+                continue
+            snapshots.append(self._build_player_snapshot(payload))
+        return snapshots
+
+    def _build_player_snapshot(self, p: dict) -> dict:
+        team = p.get("TeamNum", -1)
+        return {
+            "match_guid": self.match_guid,
+            "player_id": p.get("PrimaryId"),
+            "player_name": p.get("Name"),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "ended_at": datetime.now(timezone.utc).isoformat(),
+            "blue_score": self.blue_score,
+            "orange_score": self.orange_score,
+            "me_team": team,
+            "team_size": self.team_size,
+            "won": self._won_for_team(team),
+            "score": p.get("Score", 0),
+            "goals": p.get("Goals", 0),
+            "shots": p.get("Shots", 0),
+            "saves": p.get("Saves", 0),
+            "assists": p.get("Assists", 0),
+            "demos": p.get("Demos", 0),
+            "touches": p.get("Touches", 0),
         }
 
     def to_db_snapshot(self) -> dict:

--- a/static/index.html
+++ b/static/index.html
@@ -70,6 +70,11 @@
           </div>
         </div>
 
+        <section class="rosters" id="rosters" hidden aria-label="Lobby roster">
+          <ul class="roster blue" id="roster-blue"></ul>
+          <ul class="roster orange" id="roster-orange"></ul>
+        </section>
+
         <div class="live-grids">
           <div class="section">
             <h3>OUTPUT</h3>

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -329,6 +329,75 @@ button:focus-visible {
   }
 }
 
+/* ── Compact rosters ────────────────────────────────────────────────── */
+
+.rosters {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+
+@media (min-width: 720px) {
+  .rosters {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.roster {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-inset);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.roster-row {
+  display: grid;
+  grid-template-columns: 1fr 2rem 5rem;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+}
+
+.roster-row.me .roster-name {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.roster-name {
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roster-boost {
+  font-weight: 700;
+  color: var(--muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.roster-bar {
+  display: block;
+  height: 0.375rem;
+  background: var(--bg);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.roster-bar-fill {
+  display: block;
+  height: 100%;
+  transition: width 0.2s ease;
+}
+
+.roster.blue .roster-bar-fill { background: var(--blue); }
+.roster.orange .roster-bar-fill { background: var(--orange); }
+
 /* ── Big stat cards (score, today record) ──────────────────────────── */
 
 .big-stats {

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -106,6 +106,52 @@
       const who = m.last_touch_name ? ` (${m.last_touch_name})` : "";
       lastEl.textContent = `${ALLOWED_TOUCH[touchKey]}${who}`;
     }
+
+    renderRosters(snap.players);
+  };
+
+  // ── Compact rosters ──────────────────────────────────────────────
+
+  const buildRosterRow = (p) => {
+    const li = document.createElement("li");
+    li.className = "roster-row" + (p.is_me ? " me" : "");
+
+    const name = document.createElement("span");
+    name.className = "roster-name";
+    name.textContent = p.name ?? "—";
+
+    const boost = document.createElement("span");
+    boost.className = "roster-boost";
+    boost.textContent = p.boost ?? 0;
+
+    const bar = document.createElement("span");
+    bar.className = "roster-bar";
+    bar.setAttribute("aria-hidden", "true");
+    const fill = document.createElement("span");
+    fill.className = "roster-bar-fill";
+    const clamped = Math.max(0, Math.min(100, Number(p.boost) || 0));
+    fill.style.width = `${clamped}%`;
+    bar.appendChild(fill);
+
+    li.append(name, boost, bar);
+    return li;
+  };
+
+  const renderRosters = (players) => {
+    const rosters = $("rosters");
+    if (!players || players.length === 0) {
+      rosters.hidden = true;
+      return;
+    }
+    rosters.hidden = false;
+    const blue = $("roster-blue");
+    const orange = $("roster-orange");
+    blue.replaceChildren();
+    orange.replaceChildren();
+    for (const p of players) {
+      const row = buildRosterRow(p);
+      (p.team === 0 ? blue : orange).appendChild(row);
+    }
   };
 
   // ── Today (detailed) render ──────────────────────────────────────

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -223,6 +223,56 @@ def test_match_ended_persists_match(fresh_state):
     assert row == (250, 1)
 
 
+def test_match_ended_persists_a_row_per_player(fresh_state):
+    """A 3v3 match should produce 6 rows on MatchEnded — one per player."""
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M_LOBBY"}})
+
+    players = [
+        {"Name": "alas",  "PrimaryId": "Steam|1|0", "TeamNum": 0, "Boost": 50,
+         "Score": 300, "Goals": 1, "Shots": 2, "Saves": 1, "Assists": 0, "Demos": 0,
+         "Touches": 5, "Speed": 0, "bOnGround": True, "bHasCar": True},
+        {"Name": "tide",  "PrimaryId": "Steam|2|0", "TeamNum": 0, "Boost": 30,
+         "Score": 200, "Goals": 0, "Shots": 1, "Saves": 2, "Assists": 1, "Demos": 0,
+         "Touches": 3, "Speed": 0, "bOnGround": True, "bHasCar": True},
+        {"Name": "kio",   "PrimaryId": "Steam|3|0", "TeamNum": 0, "Boost": 80,
+         "Score": 150, "Goals": 0, "Shots": 1, "Saves": 0, "Assists": 2, "Demos": 1,
+         "Touches": 2, "Speed": 0, "bOnGround": True, "bHasCar": True},
+        {"Name": "jstn",  "PrimaryId": "Epic|4|0",  "TeamNum": 1, "Boost": 22,
+         "Score": 250, "Goals": 1, "Shots": 3, "Saves": 1, "Assists": 0, "Demos": 0,
+         "Touches": 4, "Speed": 0, "bOnGround": True, "bHasCar": True},
+        {"Name": "zen",   "PrimaryId": "Epic|5|0",  "TeamNum": 1, "Boost": 54,
+         "Score": 180, "Goals": 0, "Shots": 1, "Saves": 1, "Assists": 1, "Demos": 0,
+         "Touches": 3, "Speed": 0, "bOnGround": True, "bHasCar": True},
+        {"Name": "flux",  "PrimaryId": "Epic|6|0",  "TeamNum": 1, "Boost": 11,
+         "Score": 110, "Goals": 0, "Shots": 0, "Saves": 0, "Assists": 0, "Demos": 1,
+         "Touches": 2, "Speed": 0, "bOnGround": True, "bHasCar": True},
+    ]
+    app.handle_event({
+        "Event": "UpdateState",
+        "Data": {
+            "MatchGuid": "M_LOBBY",
+            "Players": players,
+            "Game": {"Teams": [{"TeamNum": 0, "Score": 3}, {"TeamNum": 1, "Score": 1}],
+                     "TimeSeconds": 0, "bOvertime": False, "bReplay": False,
+                     "Arena": "stadium", "bHasTarget": False, "TeamSize": 3},
+        },
+    })
+    app.handle_event({"Event": "MatchEnded", "Data": {"MatchGuid": "M_LOBBY"}})
+
+    rows = app.db.execute(
+        "SELECT player_id, player_name, me_team, won, goals, team_size "
+        "FROM matches WHERE match_guid='M_LOBBY' ORDER BY player_id"
+    ).fetchall()
+    assert len(rows) == 6
+    # me row keeps its enriched semantics (won=1 because blue=3 > orange=1)
+    me = next(r for r in rows if r[0] == "Steam|1|0")
+    assert me[2] == 0 and me[3] == 1 and me[4] == 1 and me[5] == 3
+    # opponent row stores that player's team and a per-team won verdict
+    opp = next(r for r in rows if r[0] == "Epic|4|0")
+    assert opp[1] == "jstn" and opp[2] == 1 and opp[3] == 0 and opp[4] == 1
+
+
 def test_unknown_event_is_ignored(fresh_state):
     """Forward-compat: events the aggregator doesn't recognize must not raise."""
     app.handle_event({"Event": "ReplayStart", "Data": {}})

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -948,3 +948,86 @@ def test_ball_team_rejects_invalid_payload():
     out = agg.to_overlay_dict()
     assert out["context"]["ball_speed"] == 0.0
     assert out["context"]["ball_team"] is None
+
+
+# ── Lobby roster ────────────────────────────────────────────────────────────
+
+
+def test_overlay_dict_exposes_slim_players():
+    """to_overlay_dict surfaces a slim per-player payload for the compact roster."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+    agg.on_update_state(make_state(me_boost=42))
+
+    out = agg.to_overlay_dict()
+    assert len(out["players"]) == 2
+    me = next(p for p in out["players"] if p["is_me"])
+    opp = next(p for p in out["players"] if not p["is_me"])
+    assert me == {"id": "Steam|1|0", "name": "alas", "team": 0, "boost": 42, "is_me": True}
+    assert opp["name"] == "jstn"
+    assert opp["team"] == 1
+    assert opp["boost"] == 60
+
+
+def test_overlay_dict_players_skips_entries_without_id_or_name():
+    """A spectator or transient placeholder slot must not show up in the roster."""
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+    s = make_state()
+    s["Players"].append({"Name": "", "PrimaryId": None, "TeamNum": 1, "Boost": 0})
+    s["Players"].append({"Name": "ghost", "TeamNum": 0, "Boost": 0})  # no PrimaryId
+    agg.on_update_state(s)
+
+    out = agg.to_overlay_dict()
+    assert len(out["players"]) == 2  # only the two real players
+
+
+def test_to_db_snapshots_returns_me_plus_others():
+    """to_db_snapshots yields the enriched me-row + a slim row per other player."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+    agg.on_update_state(make_state(blue=2, orange=1))
+
+    snaps = agg.to_db_snapshots()
+    assert len(snaps) == 2
+    me_snap = next(s for s in snaps if s["player_id"] == "Steam|1|0")
+    opp_snap = next(s for s in snaps if s["player_id"] == "Epic|2|0")
+
+    # me-row carries derived metrics (boost_avg, time_supersonic_pct, ...)
+    assert "boost_avg" in me_snap
+    assert me_snap["me_team"] == 0
+    assert me_snap["won"] is True
+
+    # other-row is slim — only end-of-match player stats
+    assert opp_snap["player_name"] == "jstn"
+    assert opp_snap["me_team"] == 1
+    assert opp_snap["won"] is False
+    assert opp_snap["goals"] == 0
+    assert opp_snap["assists"] == 1
+    assert "boost_avg" not in opp_snap  # derived metrics are not built for non-me players
+
+
+def test_to_db_snapshots_skips_me_row_without_identity():
+    """If me_id was never detected, only the non-me rows are emitted."""
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+    agg.on_update_state(make_state())
+
+    snaps = agg.to_db_snapshots()
+    # Both Players have a PrimaryId so both come through; no me-row added
+    assert len(snaps) == 2
+    assert all(s.get("player_id") for s in snaps)
+
+
+def test_won_for_team_handles_each_side():
+    """The per-team won() helper used for non-me rows must mirror won() for me."""
+    agg = MatchAggregator()
+    agg.blue_score = 3
+    agg.orange_score = 1
+    assert agg._won_for_team(0) is True
+    assert agg._won_for_team(1) is False
+    assert agg._won_for_team(-1) is None
+    agg.orange_score = 3
+    assert agg._won_for_team(0) is None  # tie


### PR DESCRIPTION
First slice of the RLBS metrics we discussed (1 of 4): full lobby roster.

## Summary
- **Persistence** — every player observed during the match gets a row in `matches` on end-of-match. The `me` row keeps all derived metrics (boost_avg, positioning, mechanics); the other 5 rows carry only end-of-match Score/Goals/Shots/Saves/Assists/Demos/Touches plus `team_size`. No schema change — the existing `UNIQUE(match_guid, player_id)` makes this trivial.
- **Live overlay** — a slim `players[]` field in `to_overlay_dict()` powers a new RLBS-style compact roster (name + boost number + team-coloured boost bar). The user is highlighted with `--accent`.
- **Coach view untouched** — `/api/coach` filters by `player_id = me_id`, so the new rows are invisible there.

## Implementation notes
- `won` / `me_team` are reinterpreted per-row as that player's team and verdict. Added `_won_for_team(team)` helper; `won()` now delegates to it.
- Compact-only on the overlay (per scope decision). Detailed roster (per-player goals/shots/etc.) and the 3 remaining RLBS metric groups (discrete events, last-touch, team totals) stay in memory as follow-ups.

## Test plan
- [x] `pytest -q` (168 passing — 6 new: 4 state-aggregator, 1 won_for_team helper, 1 app-level integration verifying 6 rows persisted on MatchEnded)
- [ ] Manual: `--demo` should now show the 6-row roster with one player highlighted; team colours match the live banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)