### PR TITLE
feat(ui): live team totals (goals/saves/assists/demos)

### DIFF
--- a/app.py
+++ b/app.py
@@ -303,6 +303,10 @@ DEMO_MATCH_SNAPSHOT = {
         {"id": "Epic|5|0", "name": "zen", "team": 1, "boost": 54, "is_me": False},
         {"id": "Epic|6|0", "name": "flux", "team": 1, "boost": 11, "is_me": False},
     ],
+    "teams": {
+        "blue":   {"goals": 2, "saves": 6, "assists": 2, "demos": 2},
+        "orange": {"goals": 1, "saves": 4, "assists": 2, "demos": 1},
+    },
     "context": {
         "blue": 2, "orange": 1, "clock": 187,
         "overtime": False, "replay": False, "arena": "cs_p",

--- a/state.py
+++ b/state.py
@@ -656,6 +656,29 @@ class MatchAggregator:
     def won(self) -> bool | None:
         return self._won_for_team(self.me_team)
 
+    def _team_totals(self) -> dict:
+        """Sum Goals/Saves/Assists/Demos per team across the live Players[].
+
+        Distinct from blue_score/orange_score (which come from Game.Teams[].Score)
+        — those are the final scoreline, this is the per-team aggregation of
+        individual player counters. They usually agree on Goals but expose
+        Saves/Assists/Demos macro views that the scoreline can't.
+        """
+        totals = {0: {"goals": 0, "saves": 0, "assists": 0, "demos": 0},
+                  1: {"goals": 0, "saves": 0, "assists": 0, "demos": 0}}
+        for p in self._latest_players:
+            team = p.get("TeamNum")
+            if team not in (0, 1):
+                continue
+            for field_name, payload_key in (
+                ("goals", "Goals"),
+                ("saves", "Saves"),
+                ("assists", "Assists"),
+                ("demos", "Demos"),
+            ):
+                totals[team][field_name] += int(p.get(payload_key, 0) or 0)
+        return {"blue": totals[0], "orange": totals[1]}
+
     def _won_for_team(self, team: int) -> bool | None:
         if team not in (0, 1):
             return None
@@ -679,6 +702,7 @@ class MatchAggregator:
                 for p in self._latest_players
                 if p.get("PrimaryId") and p.get("Name")
             ],
+            "teams": self._team_totals(),
             "context": {
                 "blue": self.blue_score,
                 "orange": self.orange_score,

--- a/static/index.html
+++ b/static/index.html
@@ -75,6 +75,27 @@
           <ul class="roster orange" id="roster-orange"></ul>
         </section>
 
+        <section class="team-totals" id="team-totals" hidden aria-label="Team totals">
+          <article class="team-totals-card blue">
+            <span class="team-label">BLUE</span>
+            <ul class="grid">
+              <li><span class="k">Goals</span><span class="v" id="tt-blue-goals">0</span></li>
+              <li><span class="k">Saves</span><span class="v" id="tt-blue-saves">0</span></li>
+              <li><span class="k">Assists</span><span class="v" id="tt-blue-assists">0</span></li>
+              <li><span class="k">Demos</span><span class="v" id="tt-blue-demos">0</span></li>
+            </ul>
+          </article>
+          <article class="team-totals-card orange">
+            <span class="team-label">ORANGE</span>
+            <ul class="grid">
+              <li><span class="k">Goals</span><span class="v" id="tt-orange-goals">0</span></li>
+              <li><span class="k">Saves</span><span class="v" id="tt-orange-saves">0</span></li>
+              <li><span class="k">Assists</span><span class="v" id="tt-orange-assists">0</span></li>
+              <li><span class="k">Demos</span><span class="v" id="tt-orange-demos">0</span></li>
+            </ul>
+          </article>
+        </section>
+
         <div class="live-grids">
           <div class="section">
             <h3>OUTPUT</h3>

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -398,6 +398,42 @@ button:focus-visible {
 .roster.blue .roster-bar-fill { background: var(--blue); }
 .roster.orange .roster-bar-fill { background: var(--orange); }
 
+/* ── Team totals ────────────────────────────────────────────────────── */
+
+.team-totals {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+
+@media (min-width: 720px) {
+  .team-totals {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.team-totals-card {
+  background: var(--bg-inset);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.team-totals-card.blue { border-left-color: var(--blue); }
+.team-totals-card.orange { border-left-color: var(--orange); }
+
+.team-totals-card .team-label {
+  font-size: 0.625rem;
+  letter-spacing: 0.25em;
+  font-weight: 700;
+}
+
+.team-totals-card.blue .team-label { color: var(--blue); }
+.team-totals-card.orange .team-label { color: var(--orange); }
+
 /* ── Big stat cards (score, today record) ──────────────────────────── */
 
 .big-stats {

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -108,6 +108,28 @@
     }
 
     renderRosters(snap.players);
+    renderTeamTotals(snap.teams);
+  };
+
+  // ── Team totals ──────────────────────────────────────────────────
+
+  const renderTeamTotals = (teams) => {
+    const section = $("team-totals");
+    if (!teams) {
+      section.hidden = true;
+      return;
+    }
+    section.hidden = false;
+    const blue = teams.blue ?? {};
+    const orange = teams.orange ?? {};
+    $("tt-blue-goals").textContent = blue.goals ?? 0;
+    $("tt-blue-saves").textContent = blue.saves ?? 0;
+    $("tt-blue-assists").textContent = blue.assists ?? 0;
+    $("tt-blue-demos").textContent = blue.demos ?? 0;
+    $("tt-orange-goals").textContent = orange.goals ?? 0;
+    $("tt-orange-saves").textContent = orange.saves ?? 0;
+    $("tt-orange-assists").textContent = orange.assists ?? 0;
+    $("tt-orange-demos").textContent = orange.demos ?? 0;
   };
 
   // ── Compact rosters ──────────────────────────────────────────────

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1122,3 +1122,66 @@ def test_event_ignored_when_no_match_active():
     agg.on_goal_scored({"Scorer": {"Name": "alas"}})
     agg.on_countdown_begin({})
     assert agg.events == []
+
+
+# ── Team totals (macro view) ────────────────────────────────────────────────
+
+
+def test_team_totals_sum_per_team():
+    """teams.{blue,orange} aggregate Goals/Saves/Assists/Demos across the live
+    Players[]. Distinct from blue_score/orange_score which come from Game.Teams."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    s = make_state()
+    s["Players"] = [
+        {"Name": "alas", "PrimaryId": "Steam|1|0", "TeamNum": 0,
+         "Score": 0, "Goals": 1, "Saves": 2, "Assists": 0, "Demos": 1,
+         "Shots": 0, "Touches": 0, "Boost": 0, "Speed": 0,
+         "bOnGround": True, "bHasCar": True},
+        {"Name": "tide", "PrimaryId": "Steam|2|0", "TeamNum": 0,
+         "Score": 0, "Goals": 0, "Saves": 1, "Assists": 2, "Demos": 0,
+         "Shots": 0, "Touches": 0, "Boost": 0, "Speed": 0,
+         "bOnGround": True, "bHasCar": True},
+        {"Name": "jstn", "PrimaryId": "Epic|4|0", "TeamNum": 1,
+         "Score": 0, "Goals": 2, "Saves": 0, "Assists": 1, "Demos": 0,
+         "Shots": 0, "Touches": 0, "Boost": 0, "Speed": 0,
+         "bOnGround": True, "bHasCar": True},
+    ]
+    agg.on_update_state(s)
+
+    out = agg.to_overlay_dict()
+    assert out["teams"]["blue"] == {"goals": 1, "saves": 3, "assists": 2, "demos": 1}
+    assert out["teams"]["orange"] == {"goals": 2, "saves": 0, "assists": 1, "demos": 0}
+
+
+def test_team_totals_skip_players_without_team():
+    """Spectators / placeholders without TeamNum 0/1 must not contribute."""
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    s = make_state()
+    # Override with a single legit player + a spectator-style entry
+    s["Players"] = [
+        {"Name": "alas", "PrimaryId": "Steam|1|0", "TeamNum": 0,
+         "Score": 0, "Goals": 3, "Saves": 0, "Assists": 0, "Demos": 0,
+         "Shots": 0, "Touches": 0, "Boost": 0, "Speed": 0,
+         "bOnGround": True, "bHasCar": True},
+        {"Name": "spec", "PrimaryId": "Steam|9|0", "TeamNum": 99,
+         "Goals": 100, "Saves": 100},  # bogus team
+    ]
+    agg.on_update_state(s)
+
+    out = agg.to_overlay_dict()
+    assert out["teams"]["blue"]["goals"] == 3
+    assert out["teams"]["orange"]["goals"] == 0
+
+
+def test_team_totals_zero_when_no_players():
+    agg = MatchAggregator()
+    out = agg.to_overlay_dict()
+    assert out["teams"] == {
+        "blue":   {"goals": 0, "saves": 0, "assists": 0, "demos": 0},
+        "orange": {"goals": 0, "saves": 0, "assists": 0, "demos": 0},
+    }


### PR DESCRIPTION
Last slice of the RLBS metrics list (4 of 4): team totals.

## Summary
- `MatchAggregator._team_totals()` sums Goals/Saves/Assists/Demos across the live `Players[]` and exposes them as `teams.{blue,orange}` in `to_overlay_dict`.
- New `.team-totals` section in the live panel: two cards (blue / orange) with a 2×2 grid of stat tiles and a left-border accent keyed to team color.
- Demo snapshot updated so `--demo` renders something visible.

## Why a separate field instead of reusing scores
`context.blue/orange` come from `Game.Teams[].Score` (the actual scoreline). `teams.{blue,orange}` aggregate per-player counters. They almost always agree on goals but also surface saves / assists / demos that the scoreline can't.

## Test plan
- [x] `pytest -q` (184 passing — 3 new: aggregation correctness, skip players with bogus TeamNum, zero-state when no players yet)
- [ ] Manual: `--demo` shows blue (2 / 6 / 2 / 2) and orange (1 / 4 / 2 / 1) under the rosters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)