### PR TITLE
feat(events): capture pause/unpause as match_events rows

### DIFF
--- a/app.py
+++ b/app.py
@@ -271,6 +271,14 @@ def handle_event(event: dict) -> None:
         agg.on_round_started(data)
         return
 
+    if name == "MatchPaused":
+        agg.on_match_paused(data)
+        return
+
+    if name == "MatchUnpaused":
+        agg.on_match_unpaused(data)
+        return
+
     if name in MATCH_END_EVENTS:
         _persist_current_match()
         _broadcast_today()

--- a/state.py
+++ b/state.py
@@ -421,6 +421,16 @@ class MatchAggregator:
         """Buffer the round-start marker (no actor)."""
         self._record_event("round_started")
 
+    def on_match_paused(self, data: dict) -> None:
+        """Buffer a pause marker. Paired with a matching match_unpaused row;
+        callers wanting elapsed-pause durations can diff the two timestamps."""
+        self._record_event("match_paused")
+
+    def on_match_unpaused(self, data: dict) -> None:
+        """Buffer an unpause marker. May arrive without a paired pause if the
+        Stats API stream missed it — downstream queries should tolerate that."""
+        self._record_event("match_unpaused")
+
     def _record_event(
         self,
         type_name: str,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -202,6 +202,20 @@ def test_goal_scored_persists_to_match_events_on_end(fresh_state):
     assert {r[0] for r in rows} == {"goal", "countdown_begin", "round_started"}
 
 
+def test_pause_unpause_events_dispatched_and_persisted(fresh_state):
+    """MatchPaused and MatchUnpaused round-trip into match_events on MatchEnded."""
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M_PAUSE"}})
+    app.handle_event({"Event": "MatchPaused", "Data": {}})
+    app.handle_event({"Event": "MatchUnpaused", "Data": {}})
+    app.handle_event({"Event": "MatchEnded", "Data": {"MatchGuid": "M_PAUSE"}})
+
+    rows = app.db.execute(
+        "SELECT type FROM match_events WHERE match_guid='M_PAUSE' ORDER BY id"
+    ).fetchall()
+    assert [r[0] for r in rows] == ["match_paused", "match_unpaused"]
+
+
 def test_event_buffer_does_not_double_insert(fresh_state):
     """Calling _persist_current_match twice (MatchEnded then a stale guid
     rotation) must NOT duplicate event rows — the buffer drains on first flush."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1106,6 +1106,20 @@ def test_kickoff_cycle_events_buffered_without_actor():
         assert e["actor_team"] is None
 
 
+def test_pause_unpause_buffered_as_markers():
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    agg.on_match_paused({})
+    agg.on_match_unpaused({})
+
+    types = [e["type"] for e in agg.events]
+    assert types == ["match_paused", "match_unpaused"]
+    for e in agg.events:
+        assert e["actor_id"] is None
+        assert e["payload"] == {}
+
+
 def test_events_buffer_resets_on_new_match():
     agg = MatchAggregator()
     agg.on_initialized({"MatchGuid": "M1"})


### PR DESCRIPTION
Extends the discrete-event capture from #20 with `MatchPaused` and `MatchUnpaused`. Same plumbing, two more markers in `match_events`.

## Summary
- `MatchAggregator.on_match_paused()` / `on_match_unpaused()` buffer markers via the existing `_record_event()` helper.
- `handle_event()` dispatches the two new event names.

Downstream queries can pair the rows by `occurred_at` to derive pause durations later — kept out of this PR per YAGNI (no caller needs it yet). If the API stream drops an unpause (user quits while paused), the orphan pause row is left as-is; analytics should tolerate it.

## Test plan
- [x] `pytest -q` (186 passing — 2 new: aggregator buffer + app-level dispatch+persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)