### PR TITLE
feat(touches): per-player touch history (aggregate + granular)

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from storage import (
     coach_stats,
     load_config,
     open_db,
+    save_ball_touches,
     save_config,
     save_match,
     save_match_events,
@@ -211,14 +212,16 @@ def _persist_current_match() -> bool:
     for snap in snapshots:
         if save_match(db, snap):
             inserted += 1
-    # Drain the event buffer in the same transaction window so a duplicate
-    # call (MatchEnded + a later guid rotation) doesn't double-insert.
+    # Drain the event + touch buffers in the same transaction window so a
+    # duplicate call (MatchEnded + a later guid rotation) doesn't double-insert.
     events_inserted = save_match_events(db, agg.match_guid, agg.events)
     agg.events.clear()
-    if inserted > 0 or events_inserted > 0:
+    touches_inserted = save_ball_touches(db, agg.match_guid, agg.touch_events)
+    agg.touch_events.clear()
+    if inserted > 0 or events_inserted > 0 or touches_inserted > 0:
         log.info(
-            "saved match %s (%d player rows, %d events)",
-            agg.match_guid, inserted, events_inserted,
+            "saved match %s (%d player rows, %d events, %d touches)",
+            agg.match_guid, inserted, events_inserted, touches_inserted,
         )
         return True
     return False

--- a/state.py
+++ b/state.py
@@ -216,6 +216,13 @@ class MatchAggregator:
     # overlay can render a banner. Client de-dupes by occurred_at.
     last_goal: dict | None = None
 
+    # Per-player touch tracking. `player_hit_speeds[pid]` collects every
+    # PostHitSpeed for that PrimaryId — feeds non-me row aggregates in
+    # _build_player_snapshot. `touch_events` is the granular per-touch buffer
+    # flushed to the ball_touches table on match-end.
+    player_hit_speeds: dict[str, list[float]] = field(default_factory=dict, repr=False)
+    touch_events: list[dict] = field(default_factory=list, repr=False)
+
     def reset_match(self, match_guid: str) -> None:
         keep = (self.me_id, self.me_name)
         self.__init__()  # type: ignore[misc]
@@ -347,6 +354,24 @@ class MatchAggregator:
             t = hitter.get("TeamNum")
             if t in (0, 1):
                 self.team_hits[t] = self.team_hits.get(t, 0) + 1
+
+        # Per-player tracking: aggregates for the non-me snapshot rows, and a
+        # granular row per touch for the ball_touches table.
+        if self.match_guid is not None:
+            occurred_at = datetime.now(timezone.utc).isoformat()
+            for hitter in hitters:
+                pid = hitter.get("PrimaryId")
+                if not pid:
+                    continue
+                self.player_hit_speeds.setdefault(pid, []).append(post)
+                team_num = hitter.get("TeamNum")
+                self.touch_events.append({
+                    "player_id": pid,
+                    "player_name": hitter.get("Name"),
+                    "team": team_num if team_num in (0, 1) else None,
+                    "post_hit_speed": post,
+                    "occurred_at": occurred_at,
+                })
 
         if not self.me_name:
             return
@@ -779,9 +804,11 @@ class MatchAggregator:
 
     def _build_player_snapshot(self, p: dict) -> dict:
         team = p.get("TeamNum", -1)
+        pid = p.get("PrimaryId")
+        speeds = self.player_hit_speeds.get(pid, []) if pid else []
         return {
             "match_guid": self.match_guid,
-            "player_id": p.get("PrimaryId"),
+            "player_id": pid,
             "player_name": p.get("Name"),
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "ended_at": datetime.now(timezone.utc).isoformat(),
@@ -797,6 +824,9 @@ class MatchAggregator:
             "assists": p.get("Assists", 0),
             "demos": p.get("Demos", 0),
             "touches": p.get("Touches", 0),
+            "ball_hits": len(speeds),
+            "hardest_hit": round(max(speeds), 1) if speeds else 0.0,
+            "avg_shot_power": round(sum(speeds) / len(speeds), 1) if speeds else 0.0,
         }
 
     def to_db_snapshot(self) -> dict:

--- a/storage.py
+++ b/storage.py
@@ -138,6 +138,18 @@ CREATE TABLE IF NOT EXISTS match_events (
 CREATE INDEX IF NOT EXISTS idx_match_events_guid ON match_events(match_guid);
 CREATE INDEX IF NOT EXISTS idx_match_events_type ON match_events(type);
 
+CREATE TABLE IF NOT EXISTS ball_touches (
+    id INTEGER PRIMARY KEY,
+    match_guid TEXT NOT NULL,
+    player_id TEXT NOT NULL,
+    player_name TEXT,
+    team INTEGER,
+    post_hit_speed REAL,
+    occurred_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ball_touches_guid ON ball_touches(match_guid);
+CREATE INDEX IF NOT EXISTS idx_ball_touches_player ON ball_touches(player_id);
+
 CREATE TABLE IF NOT EXISTS matches (
     id INTEGER PRIMARY KEY,
     match_guid TEXT NOT NULL,
@@ -268,6 +280,37 @@ def get_match_events(conn: sqlite3.Connection, match_guid: str) -> list[dict]:
             "payload": payload,
         })
     return out
+
+
+def save_ball_touches(
+    conn: sqlite3.Connection, match_guid: str | None, touches: list[dict]
+) -> int:
+    """Insert every buffered ball touch. Returns the number of rows written.
+
+    Same caller-clears-buffer convention as save_match_events: there is no
+    UNIQUE constraint so replaying the same list would duplicate rows.
+    """
+    if not match_guid or not touches:
+        return 0
+    rows = [
+        (
+            match_guid,
+            touch["player_id"],
+            touch.get("player_name"),
+            touch.get("team"),
+            touch.get("post_hit_speed"),
+            touch["occurred_at"],
+        )
+        for touch in touches
+    ]
+    conn.executemany(
+        "INSERT INTO ball_touches "
+        "(match_guid, player_id, player_name, team, post_hit_speed, occurred_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    return len(rows)
 
 
 def save_match_events(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -235,6 +235,36 @@ def test_event_buffer_does_not_double_insert(fresh_state):
     assert count == 1
 
 
+def test_ball_hits_persist_to_ball_touches_on_end(fresh_state):
+    """BallHit during the match → ball_touches rows on MatchEnded, drained
+    so a second persist doesn't duplicate."""
+    app.agg.me_id, app.agg.me_name = "Steam|1|0", "alas"
+    app.handle_event({"Event": "MatchInitialized", "Data": {"MatchGuid": "M_TOUCHES"}})
+
+    for speed in (45.0, 78.5, 92.0):
+        app.handle_event({
+            "Event": "BallHit",
+            "Data": {
+                "Ball": {"PostHitSpeed": speed},
+                "Players": [{"PrimaryId": "Steam|1|0", "Name": "alas", "TeamNum": 0}],
+            },
+        })
+    app.handle_event({"Event": "MatchEnded", "Data": {"MatchGuid": "M_TOUCHES"}})
+
+    rows = app.db.execute(
+        "SELECT post_hit_speed FROM ball_touches "
+        "WHERE match_guid='M_TOUCHES' ORDER BY id"
+    ).fetchall()
+    assert [r[0] for r in rows] == [45.0, 78.5, 92.0]
+
+    # Idempotency — second flush must not duplicate
+    app._persist_current_match()
+    count = app.db.execute(
+        "SELECT COUNT(*) FROM ball_touches WHERE match_guid='M_TOUCHES'"
+    ).fetchone()[0]
+    assert count == 3
+
+
 def test_match_destroyed_persists_match(fresh_state):
     """If RL emits MatchDestroyed instead of MatchEnded (user quits mid-match
     or the session is torn down), the in-progress match must still be saved."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1227,3 +1227,92 @@ def test_last_goal_resets_on_new_match():
 
     agg.on_initialized({"MatchGuid": "M2"})
     assert agg.last_goal is None
+
+
+# ── Per-player touch tracking ───────────────────────────────────────────────
+
+
+def test_on_ball_hit_tracks_speeds_for_every_hitter_with_id():
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    agg.on_ball_hit({
+        "Ball": {"PostHitSpeed": 80.0},
+        "Players": [
+            {"PrimaryId": "Steam|1|0", "Name": "alas", "TeamNum": 0},
+            {"PrimaryId": "Epic|2|0", "Name": "jstn", "TeamNum": 1},
+        ],
+    })
+    agg.on_ball_hit({
+        "Ball": {"PostHitSpeed": 110.0},
+        "Players": [{"PrimaryId": "Steam|1|0", "Name": "alas", "TeamNum": 0}],
+    })
+
+    assert agg.player_hit_speeds["Steam|1|0"] == [80.0, 110.0]
+    assert agg.player_hit_speeds["Epic|2|0"] == [80.0]
+    assert len(agg.touch_events) == 3
+    assert agg.touch_events[0]["player_id"] == "Steam|1|0"
+    assert agg.touch_events[0]["post_hit_speed"] == 80.0
+
+
+def test_on_ball_hit_skips_hitters_without_primary_id():
+    """Spectator-style entries without PrimaryId must not pollute the buffers."""
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+
+    agg.on_ball_hit({
+        "Ball": {"PostHitSpeed": 50.0},
+        "Players": [
+            {"Name": "ghost", "TeamNum": 0},  # no PrimaryId
+            {"PrimaryId": "Steam|1|0", "Name": "alas", "TeamNum": 0},
+        ],
+    })
+
+    assert list(agg.player_hit_speeds.keys()) == ["Steam|1|0"]
+    assert len(agg.touch_events) == 1
+
+
+def test_build_player_snapshot_derives_touch_aggregates():
+    """Non-me rows get ball_hits / hardest_hit / avg_shot_power from the
+    per-player speed buffer."""
+    agg = MatchAggregator()
+    agg.me_id, agg.me_name = "Steam|1|0", "alas"
+    agg.on_initialized({"MatchGuid": "M1"})
+    agg.on_update_state(make_state(blue=2, orange=1))
+
+    for speed in (40.0, 60.0, 95.0):
+        agg.on_ball_hit({
+            "Ball": {"PostHitSpeed": speed},
+            "Players": [{"PrimaryId": "Epic|2|0", "Name": "jstn", "TeamNum": 1}],
+        })
+
+    snaps = agg.to_db_snapshots()
+    opp = next(s for s in snaps if s["player_id"] == "Epic|2|0")
+    assert opp["ball_hits"] == 3
+    assert opp["hardest_hit"] == 95.0
+    assert opp["avg_shot_power"] == round((40 + 60 + 95) / 3, 1)
+
+
+def test_touch_buffers_reset_on_new_match():
+    agg = MatchAggregator()
+    agg.on_initialized({"MatchGuid": "M1"})
+    agg.on_ball_hit({
+        "Ball": {"PostHitSpeed": 50.0},
+        "Players": [{"PrimaryId": "Steam|1|0", "Name": "alas", "TeamNum": 0}],
+    })
+    assert agg.player_hit_speeds and agg.touch_events
+
+    agg.on_initialized({"MatchGuid": "M2"})
+    assert agg.player_hit_speeds == {}
+    assert agg.touch_events == []
+
+
+def test_ball_hit_ignored_before_match_initialized():
+    """Touches that arrive before MatchInitialized are dropped silently."""
+    agg = MatchAggregator()
+    agg.on_ball_hit({
+        "Ball": {"PostHitSpeed": 50.0},
+        "Players": [{"PrimaryId": "Steam|1|0", "Name": "alas", "TeamNum": 0}],
+    })
+    assert agg.player_hit_speeds == {}
+    assert agg.touch_events == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,6 +12,7 @@ from storage import (  # noqa: E402
     coach_stats,
     get_match_events,
     open_db,
+    save_ball_touches,
     save_match,
     save_match_events,
     today_stats,
@@ -809,6 +810,43 @@ def test_coach_stats_last_match_events_empty_when_no_last_match(tmp_path):
     db = open_db(tmp_path / "stats.db")
     result = coach_stats(db, "Steam|1|0")
     assert result["last_match_events"] == []
+
+
+# ── ball_touches ────────────────────────────────────────────────────────────
+
+
+def test_open_db_creates_ball_touches_table(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    cols = {row[1] for row in db.execute("PRAGMA table_info(ball_touches)")}
+    assert {"id", "match_guid", "player_id", "player_name", "team",
+            "post_hit_speed", "occurred_at"} <= cols
+
+
+def test_save_ball_touches_persists_rows(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    touches = [
+        {"player_id": "Steam|1|0", "player_name": "alas", "team": 0,
+         "post_hit_speed": 92.5, "occurred_at": "2026-05-13T20:00:01+00:00"},
+        {"player_id": "Epic|2|0", "player_name": "jstn", "team": 1,
+         "post_hit_speed": 60.0, "occurred_at": "2026-05-13T20:00:02+00:00"},
+    ]
+
+    inserted = save_ball_touches(db, "M1", touches)
+    assert inserted == 2
+
+    rows = db.execute(
+        "SELECT player_name, team, post_hit_speed FROM ball_touches "
+        "WHERE match_guid='M1' ORDER BY id"
+    ).fetchall()
+    assert rows == [("alas", 0, 92.5), ("jstn", 1, 60.0)]
+
+
+def test_save_ball_touches_noop_for_empty_inputs(tmp_path):
+    db = open_db(tmp_path / "stats.db")
+    assert save_ball_touches(db, "M1", []) == 0
+    assert save_ball_touches(db, None, [
+        {"player_id": "x", "occurred_at": "y", "post_hit_speed": 1.0}
+    ]) == 0
 
 
 def test_migration_adds_team_size_column_to_existing_db(tmp_path):


### PR DESCRIPTION
Closes the last partial from the 4 RLBS metric groups: per-player touch history.

## Summary

### Aggregates — cheap, lives on existing match rows
- `MatchAggregator.player_hit_speeds` maps `PrimaryId → list[PostHitSpeed]` for every `BallHit` observed.
- `_build_player_snapshot` now derives `ball_hits`, `hardest_hit`, and `avg_shot_power` per non-me player from that buffer. The me row keeps its existing self-tracked values (which match what the buffer would derive).

### Granular — one row per touch
- New `ball_touches` table `(match_guid, player_id, player_name, team, post_hit_speed, occurred_at)` plus two indexes (`match_guid`, `player_id`). Created additively in the `executescript` bootstrap, so old DBs pick it up on first open.
- `save_ball_touches` drains the buffer inside `_persist_current_match`; same caller-clears convention as `save_match_events`, so a duplicate persist call doesn't double-insert.

## Why both
\"Aggregates\" answers \"how hard does my teammate usually hit?\" with a cheap query against `matches`. \"Granular\" enables histograms, top-N picks, and time-windowed analysis (\"hardest hits in the last 30 s of a match\") that aggregates can't.

## Test plan
- [x] `pytest -q` (201 passing — 9 new: 5 aggregator buffer + scope checks, 3 storage round-trip + creation + noop, 1 app-level integration that also asserts idempotency on the second persist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)