### PR TITLE
fix(ui): UI/UX agent P0 — header layout, motion safety, color tokens

### DIFF
--- a/static/overlay.css
+++ b/static/overlay.css
@@ -81,8 +81,8 @@ button:focus-visible {
 /* ── Header ─────────────────────────────────────────────────────────── */
 
 .page-header {
-  display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-4);
   padding: var(--space-3) var(--space-5);
@@ -99,6 +99,10 @@ button:focus-visible {
   justify-content: center;
   gap: var(--space-3);
   font-weight: 700;
+  /* Centers inside the flex header when present; the row collapses to zero
+   * width when [hidden] so the controls on the right don't drift away from
+   * the heading. */
+  margin-inline: auto;
 }
 .header-scoreline .team {
   font-size: 0.625rem;
@@ -187,7 +191,7 @@ button:focus-visible {
 }
 
 .mode-tabs {
-  grid-column: 1 / -1;
+  flex-basis: 100%;
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-1);
@@ -307,13 +311,15 @@ button:focus-visible {
   font-size: 0.9375rem;
 }
 
-.goal-banner.show {
-  animation: goal-pulse 0.35s ease-out;
-}
+@media (prefers-reduced-motion: no-preference) {
+  .goal-banner.show {
+    animation: goal-pulse 0.35s ease-out;
+  }
 
-@keyframes goal-pulse {
-  from { transform: scale(0.85); opacity: 0; }
-  to   { transform: scale(1); opacity: 1; }
+  @keyframes goal-pulse {
+    from { transform: scale(0.85); opacity: 0; }
+    to   { transform: scale(1); opacity: 1; }
+  }
 }
 
 .me-line {
@@ -327,6 +333,8 @@ button:focus-visible {
   letter-spacing: 0.04em;
 }
 .me-line #me-name { color: var(--fg); font-weight: 600; }
+.me-line #me-team[data-team="blue"] { color: var(--blue); }
+.me-line #me-team[data-team="orange"] { color: var(--orange); }
 .me-line .dot::before { content: "•"; color: var(--muted); }
 
 .live-pill {

--- a/static/overlay.js
+++ b/static/overlay.js
@@ -71,8 +71,11 @@
 
     $("me-name").textContent = me.name ?? "detecting…";
     const teamLabel = me.team === 0 ? "blue team" : me.team === 1 ? "orange team" : "—";
-    $("me-team").textContent = teamLabel;
-    $("me-team").style.color = me.team === 0 ? "#1873ff" : me.team === 1 ? "#ff8a1f" : "";
+    const meTeamEl = $("me-team");
+    meTeamEl.textContent = teamLabel;
+    if (me.team === 0) meTeamEl.dataset.team = "blue";
+    else if (me.team === 1) meTeamEl.dataset.team = "orange";
+    else delete meTeamEl.dataset.team;
 
     $("m-score").textContent = m.score ?? 0;
     $("m-boost").textContent = m.boost ?? 0;


### PR DESCRIPTION
Three bugs surfaced by the ui-ux agent review before the visual demo (1/3 PRs from the review).

## Fixes
- **Header layout** — was a 4-col grid with a `1fr` for the live scoreline. When the scoreline is hidden, the column kept its width and left a large gap between title and right-hand controls. Switched to flex with `margin-inline: auto` on the scoreline so it collapses to zero when hidden and centres when present. `mode-tabs` still spans the second row via `flex-basis: 100%`.
- **`goal-pulse` + `prefers-reduced-motion`** — the global reduced-motion override clamped animation duration to 0.01ms, but it still ran the \"from\" keyframe (opacity 0, scale 0.85) briefly, producing a flicker for users who opted out of motion. Wrapped the rule in `@media (prefers-reduced-motion: no-preference)` so it never registers when motion is disabled.
- **Hardcoded team colors in `renderMatch`** — was setting `me-team.style.color` to literal `#1873ff`/`#ff8a1f`, duplicating the `--blue`/`--orange` tokens. Now toggles `data-team` and lets CSS read from the root vars.

PRs 2 (P1 selectivo) and 3 (rebalanceo de live section) van detrás.

## Test plan
- [x] `pytest -q` (201 passing — no test changes, pure CSS/JS refactor)
- [ ] Manual `--demo`: header sin hueco, `me-team` con color correcto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)