### PR TITLE
fix(ui): UI/UX agent P1 — labels, focus, color tokens, roster identity

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -36,6 +36,7 @@
       </label>
       <span class="conn" id="conn" aria-live="polite" data-state="connecting">connecting…</span>
       <nav class="mode-tabs" id="mode-tabs" aria-label="Filter coach stats by match mode">
+        <span class="mode-tabs-label">Coach view</span>
         <button type="button" class="mode-tab" data-mode="" aria-pressed="true">All</button>
         <button type="button" class="mode-tab" data-mode="1" aria-pressed="false">1v1</button>
         <button type="button" class="mode-tab" data-mode="2" aria-pressed="false">2v2</button>
@@ -170,7 +171,7 @@
       </section>
 
       <section class="events" id="events-section" hidden aria-labelledby="events-heading">
-        <h2 id="events-heading">Last match timeline</h2>
+        <h2 id="events-heading">Timeline</h2>
         <ul class="events-list" id="events-list"></ul>
       </section>
 

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -194,8 +194,18 @@ button:focus-visible {
   flex-basis: 100%;
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-1);
   padding-top: var(--space-2);
+}
+
+.mode-tabs-label {
+  font-size: 0.625rem;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-right: var(--space-2);
 }
 
 .mode-tab {
@@ -220,6 +230,14 @@ button:focus-visible {
   background: var(--accent);
   color: var(--fg-inverse);
   border-color: var(--accent);
+}
+
+/* Default focus-visible outline is --accent; on the active tab the accent
+ * is also the background, so swap the outline to the inverse foreground
+ * and add offset so the ring is visible. */
+.mode-tab[aria-pressed="true"]:focus-visible {
+  outline-color: var(--fg-inverse);
+  outline-offset: 3px;
 }
 
 /* ── Layout ─────────────────────────────────────────────────────────── */
@@ -283,7 +301,7 @@ button:focus-visible {
   font-weight: 800;
 }
 .banner.replay { background: #c084fc; color: var(--fg-inverse); }
-.banner.overtime { background: var(--bad); color: #fff; }
+.banner.overtime { background: var(--bad); color: var(--fg); }
 
 .goal-banner {
   align-self: center;
@@ -298,7 +316,7 @@ button:focus-visible {
   letter-spacing: 0.04em;
 }
 
-.goal-banner[data-team="blue"] { background: var(--blue); color: #fff; }
+.goal-banner[data-team="blue"] { background: var(--blue); color: var(--fg); }
 .goal-banner[data-team="orange"] { background: var(--orange); color: var(--fg-inverse); }
 
 .goal-banner-label {
@@ -340,7 +358,7 @@ button:focus-visible {
 .live-pill {
   display: inline-flex;
   align-items: baseline;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 .live-pill .pill-k {
   text-transform: uppercase;
@@ -392,10 +410,14 @@ button:focus-visible {
   padding: var(--space-2) var(--space-3);
   background: var(--bg-inset);
   border-radius: var(--radius-sm);
+  border-left: 3px solid;
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
 }
+
+.roster.blue   { border-left-color: var(--blue); }
+.roster.orange { border-left-color: var(--orange); }
 
 .roster-row {
   display: grid;


### PR DESCRIPTION
Second slice of the ui-ux agent review (2/3 PRs).

## Fixes
- **Mode tabs scope ambiguity** — they sit on top of the live panel but only affect `/api/coach` and `/api/today`. Added a `Coach view` label inside the nav so the scope is explicit at a glance.
- **Invisible focus ring on active mode tab** — `aria-pressed=\"true\"` already paints the tab with `--accent`; the global `:focus-visible` outline is also `--accent`, so tabbing onto the active tab gave no visual feedback. Added a targeted `:focus-visible` that uses `--fg-inverse` with a 3 px offset.
- **Rosters vs. team-totals identity** — both lived in cards with identical bg / border-radius and only the boost-bar fill at the far right hinted at which team it was. Added the same coloured `border-left` rosters already use on team-totals so the per-player / per-team cards stay in the same family but read as separate compartments.
- **Hardcoded values** — replaced `#fff` with `var(--fg)` in `.banner.overtime` and `.goal-banner[data-team=\"blue\"]`; replaced `0.25rem` with `var(--space-1)` in `.live-pill`.
- **Timeline title repetition** — \"Last match timeline\" was just below the hero h2 \"Last match\". Trimmed to \"Timeline\".

## Test plan
- [x] `pytest -q` (201 passing — CSS/markup only)
- [ ] Manual `--demo`: rosters muestran su color de team a la izquierda, mode tabs tienen prefijo \"Coach view\", goal banner blue se ve legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)