### PR TITLE
fix(ui): rebalance the live section per UI/UX review

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -65,43 +65,40 @@
             <span class="dot"></span>
             <span class="live-pill"><span class="pill-k">boost</span><span class="pill-v" id="m-boost">0</span><span class="pill-suffix">%</span></span>
             <span class="live-pill"><span class="pill-k">speed</span><span class="pill-v" id="m-speed">0</span></span>
+            <span class="live-pill score"><span class="pill-k">score</span><span class="pill-v" id="m-score">0</span></span>
           </div>
         </header>
 
-        <div class="big-stats">
-          <div class="big-stat score">
-            <span class="label">SCORE</span>
-            <span class="val" id="m-score">0</span>
-          </div>
-        </div>
+        <details class="match-details" open>
+          <summary>Match details</summary>
 
-        <section class="rosters" id="rosters" hidden aria-label="Lobby roster">
-          <ul class="roster blue" id="roster-blue"></ul>
-          <ul class="roster orange" id="roster-orange"></ul>
-        </section>
+          <section class="rosters" id="rosters" hidden aria-label="Lobby roster">
+            <ul class="roster blue" id="roster-blue"></ul>
+            <ul class="roster orange" id="roster-orange"></ul>
+          </section>
 
-        <section class="team-totals" id="team-totals" hidden aria-label="Team totals">
-          <article class="team-totals-card blue">
-            <span class="team-label">BLUE</span>
-            <ul class="grid">
-              <li><span class="k">Goals</span><span class="v" id="tt-blue-goals">0</span></li>
-              <li><span class="k">Saves</span><span class="v" id="tt-blue-saves">0</span></li>
-              <li><span class="k">Assists</span><span class="v" id="tt-blue-assists">0</span></li>
-              <li><span class="k">Demos</span><span class="v" id="tt-blue-demos">0</span></li>
-            </ul>
-          </article>
-          <article class="team-totals-card orange">
-            <span class="team-label">ORANGE</span>
-            <ul class="grid">
-              <li><span class="k">Goals</span><span class="v" id="tt-orange-goals">0</span></li>
-              <li><span class="k">Saves</span><span class="v" id="tt-orange-saves">0</span></li>
-              <li><span class="k">Assists</span><span class="v" id="tt-orange-assists">0</span></li>
-              <li><span class="k">Demos</span><span class="v" id="tt-orange-demos">0</span></li>
-            </ul>
-          </article>
-        </section>
+          <section class="team-totals" id="team-totals" hidden aria-label="Team totals">
+            <article class="team-totals-card blue">
+              <span class="team-label">BLUE</span>
+              <ul class="grid">
+                <li><span class="k">Goals</span><span class="v" id="tt-blue-goals">0</span></li>
+                <li><span class="k">Saves</span><span class="v" id="tt-blue-saves">0</span></li>
+                <li><span class="k">Assists</span><span class="v" id="tt-blue-assists">0</span></li>
+                <li><span class="k">Demos</span><span class="v" id="tt-blue-demos">0</span></li>
+              </ul>
+            </article>
+            <article class="team-totals-card orange">
+              <span class="team-label">ORANGE</span>
+              <ul class="grid">
+                <li><span class="k">Goals</span><span class="v" id="tt-orange-goals">0</span></li>
+                <li><span class="k">Saves</span><span class="v" id="tt-orange-saves">0</span></li>
+                <li><span class="k">Assists</span><span class="v" id="tt-orange-assists">0</span></li>
+                <li><span class="k">Demos</span><span class="v" id="tt-orange-demos">0</span></li>
+              </ul>
+            </article>
+          </section>
 
-        <div class="live-grids">
+          <div class="live-grids">
           <div class="section">
             <h3>OUTPUT</h3>
             <ul class="grid">
@@ -150,7 +147,8 @@
               <li><span class="k">Demos taken</span><span class="v" id="m-demos-taken">0</span></li>
             </ul>
           </div>
-        </div>
+          </div>
+        </details>
       </section>
 
       <section class="hero" id="hero" hidden aria-labelledby="last-heading">

--- a/static/overlay.css
+++ b/static/overlay.css
@@ -378,6 +378,48 @@ button:focus-visible {
   font-weight: 600;
 }
 
+/* Score gets a touch of emphasis without becoming a separate card. */
+.live-pill.score .pill-k { color: var(--accent); }
+.live-pill.score .pill-v { font-size: 1rem; }
+
+/* ── Match details disclosure ───────────────────────────────────────── */
+
+.match-details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.match-details > summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
+  border-bottom: 1px dashed var(--border);
+  font-size: 0.625rem;
+  letter-spacing: 0.25em;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.match-details > summary::-webkit-details-marker { display: none; }
+
+.match-details > summary::before {
+  content: "▸";
+  color: var(--accent);
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+
+.match-details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.match-details > summary:hover { color: var(--fg); }
+
 .live-grids {
   display: grid;
   grid-template-columns: 1fr;


### PR DESCRIPTION
Third and final slice of the ui-ux agent review (3/3 PRs).

## Summary
Two changes that together cut the live section from ~7 stacked blocks to a tactical-up / descriptive-down structure:

1. **Score moves into `me-line`.** Folded the lone-card SCORE big-stat into the identity line as another live-pill (with a touch of `--accent` on its label and slightly bigger `pill-v`). Eliminates one of three spots that were showing the score simultaneously and reclaims a full row of width that was used for a single number.
2. **Match details collapse into a `<details>`.** Wrapped rosters + team-totals + live-grids inside a `<details class=\"match-details\" open>` with an \"eyebrow\" summary and a rotating ▸ chevron. Default is `open` so behaviour is preserved for users who want everything visible; users who find the density distracting can collapse it and still see header scoreline + identity line (with boost/speed/score) + goal banner.

The agent's recommendation was \"jerarquía: lo táctico arriba grande, lo descriptivo abajo o colapsable\". This is the colapsable variant with backwards-compatible defaults.

## Test plan
- [x] `pytest -q` (201 passing — markup/CSS only)
- [ ] Manual `--demo`: live se ve más ligero, score visible en me-line, summary plegable funciona, chevron rota al expandir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)